### PR TITLE
Fix desynched actors_active_tail when actor are being deactivated

### DIFF
--- a/plugins/Mico27/EditActorActiveIndexPlugin/engine/src/core/actor.c
+++ b/plugins/Mico27/EditActorActiveIndexPlugin/engine/src/core/actor.c
@@ -204,6 +204,9 @@ void deactivate_actor(actor_t *actor) BANKED {
     if (actor == &PLAYER) return;
     actor->active = FALSE;
     DL_REMOVE_ITEM(actors_active_head, actor);
+	if (actors_active_tail == actor){
+		actors_active_tail = actor->prev;
+	}
     DL_PUSH_HEAD(actors_inactive_head, actor);
     if ((actor->hscript_update & SCRIPT_TERMINATED) == 0) {
         script_terminate(actor->hscript_update);

--- a/plugins/Mico27/FlickerActorPlugin/engine/src/core/actor.c
+++ b/plugins/Mico27/FlickerActorPlugin/engine/src/core/actor.c
@@ -213,6 +213,9 @@ void deactivate_actor(actor_t *actor) BANKED {
     if (actor == &PLAYER) return;
     actor->active = FALSE;
     DL_REMOVE_ITEM(actors_active_head, actor);
+	if (actors_active_tail == actor){
+		actors_active_tail = actor->prev;
+	}
     DL_PUSH_HEAD(actors_inactive_head, actor);
     if ((actor->hscript_update & SCRIPT_TERMINATED) == 0) {
         script_terminate(actor->hscript_update);

--- a/plugins/Mico27/FlickerActorPlugin/engine/src/core/actor.c
+++ b/plugins/Mico27/FlickerActorPlugin/engine/src/core/actor.c
@@ -185,7 +185,7 @@ void actors_update(void) NONBANKED {
     }
 	//pop n push for flicker
 	actor = actors_active_tail;
-	if (actor->prev){
+	if (actor != actors_active_head){
 	    actor->next = actors_active_head;
 	    actors_active_head->prev = actor;
 	    actors_active_head = actor;


### PR DESCRIPTION
Flicker actor plugin and Edit actor active Index plugin allow to move the player actor along the active actor list, therefore, actors_active_tail (which was always the player actor before) can change. When deactivating an actor, if the actor happens to be at the end of the active list, the function wasn't updating the actors_active_tail after removing the actor.