### PR TITLE
Update Mico27 Plugins

### DIFF
--- a/plugins/Mico27/ConfigLoadSavePlugin/engine/src/core/load_save.c.patch
+++ b/plugins/Mico27/ConfigLoadSavePlugin/engine/src/core/load_save.c.patch
@@ -167,7 +167,7 @@ Index: src\core\load_save.c
      if (music_current_track_bank != MUSIC_STOP_BANK) {
          music_next_track = music_current_track;
      } else {
-@@ -149,14 +219,44 @@
+@@ -149,14 +219,47 @@
  #ifdef BATTERYLESS
      // save to FLASH ROM
      save_sram(SRAM_BANKS_TO_SAVE);
@@ -203,7 +203,10 @@ Index: src\core\load_save.c
 +}
 +
 +void vm_data_peek_ex(SCRIPT_CTX * THIS) OLDCALL BANKED {
-+    data_peek_ex(*(uint8_t *)VM_REF_TO_PTR(FN_ARG0), *(uint16_t *)VM_REF_TO_PTR(FN_ARG1), *(uint16_t *)VM_REF_TO_PTR(FN_ARG2), &script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG3)]);
++    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG3);
++    int16_t * A;
++    if (idx < 0) A = THIS->stack_ptr + idx - 4; else A = script_memory + idx;
++    data_peek_ex(*(uint8_t *)VM_REF_TO_PTR(FN_ARG0), *(uint16_t *)VM_REF_TO_PTR(FN_ARG1), *(uint16_t *)VM_REF_TO_PTR(FN_ARG2), A);
 +}
 +
 +void vm_data_save_ex(SCRIPT_CTX * THIS) OLDCALL BANKED {

--- a/plugins/Mico27/ConfigLoadSavePlugin/engineAlt/M/src/core/load_save.c.patch
+++ b/plugins/Mico27/ConfigLoadSavePlugin/engineAlt/M/src/core/load_save.c.patch
@@ -130,7 +130,7 @@ Index: src\core\load_save.c
      // Restart music
      if (music_current_track_bank != MUSIC_STOP_BANK) {
          music_next_track = music_current_track;
-@@ -180,4 +234,29 @@
+@@ -180,4 +234,32 @@
      if (count) memcpy(dest, save_data + (sizeof(save_signature) + sizeof(save_blob_size) + sizeof(size_t) + sizeof(uint8_t)) + (idx << 1), count << 1);
      SWITCH_RAM_BANK(0, RAM_BANKS_ONLY);
      return TRUE;
@@ -150,7 +150,10 @@ Index: src\core\load_save.c
 +}
 +
 +void vm_data_peek_ex(SCRIPT_CTX * THIS) OLDCALL BANKED {
-+    data_peek_ex(*(uint8_t *)VM_REF_TO_PTR(FN_ARG0), *(uint16_t *)VM_REF_TO_PTR(FN_ARG1), *(uint16_t *)VM_REF_TO_PTR(FN_ARG2), &script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG3)]);
++    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG3);
++    int16_t * A;
++    if (idx < 0) A = THIS->stack_ptr + idx - 4; else A = script_memory + idx;
++    data_peek_ex(*(uint8_t *)VM_REF_TO_PTR(FN_ARG0), *(uint16_t *)VM_REF_TO_PTR(FN_ARG1), *(uint16_t *)VM_REF_TO_PTR(FN_ARG2), A);
 +}
 +
 +void vm_data_save_ex(SCRIPT_CTX * THIS) OLDCALL BANKED {

--- a/plugins/Mico27/ConfigLoadSavePlugin/engineAlt/M_Sce/src/core/load_save.c.patch
+++ b/plugins/Mico27/ConfigLoadSavePlugin/engineAlt/M_Sce/src/core/load_save.c.patch
@@ -130,7 +130,7 @@ Index: src\core\load_save.c
      // Restart music
      if (music_current_track_bank != MUSIC_STOP_BANK) {
          music_next_track = music_current_track;
-@@ -180,4 +234,29 @@
+@@ -180,4 +234,32 @@
      if (count) memcpy(dest, save_data + (sizeof(save_signature) + sizeof(save_blob_size) + sizeof(size_t) + sizeof(uint8_t)) + (idx << 1), count << 1);
      SWITCH_RAM_BANK(0, RAM_BANKS_ONLY);
      return TRUE;
@@ -150,7 +150,10 @@ Index: src\core\load_save.c
 +}
 +
 +void vm_data_peek_ex(SCRIPT_CTX * THIS) OLDCALL BANKED {
-+    data_peek_ex(*(uint8_t *)VM_REF_TO_PTR(FN_ARG0), *(uint16_t *)VM_REF_TO_PTR(FN_ARG1), *(uint16_t *)VM_REF_TO_PTR(FN_ARG2), &script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG3)]);
++    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG3);
++    int16_t * A;
++    if (idx < 0) A = THIS->stack_ptr + idx - 4; else A = script_memory + idx;
++    data_peek_ex(*(uint8_t *)VM_REF_TO_PTR(FN_ARG0), *(uint16_t *)VM_REF_TO_PTR(FN_ARG1), *(uint16_t *)VM_REF_TO_PTR(FN_ARG2), A);
 +}
 +
 +void vm_data_save_ex(SCRIPT_CTX * THIS) OLDCALL BANKED {

--- a/plugins/Mico27/ConfigLoadSavePlugin/engineAlt/Sce/src/core/load_save.c.patch
+++ b/plugins/Mico27/ConfigLoadSavePlugin/engineAlt/Sce/src/core/load_save.c.patch
@@ -130,7 +130,7 @@ Index: src\core\load_save.c
      // Restart music
      if (music_current_track_bank != MUSIC_STOP_BANK) {
          music_next_track = music_current_track;
-@@ -180,4 +234,29 @@
+@@ -180,4 +234,32 @@
      if (count) memcpy(dest, save_data + (sizeof(save_signature) + sizeof(save_blob_size) + sizeof(size_t) + sizeof(uint8_t)) + (idx << 1), count << 1);
      SWITCH_RAM_BANK(0, RAM_BANKS_ONLY);
      return TRUE;
@@ -150,7 +150,10 @@ Index: src\core\load_save.c
 +}
 +
 +void vm_data_peek_ex(SCRIPT_CTX * THIS) OLDCALL BANKED {
-+    data_peek_ex(*(uint8_t *)VM_REF_TO_PTR(FN_ARG0), *(uint16_t *)VM_REF_TO_PTR(FN_ARG1), *(uint16_t *)VM_REF_TO_PTR(FN_ARG2), &script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG3)]);
++    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG3);
++    int16_t * A;
++    if (idx < 0) A = THIS->stack_ptr + idx - 4; else A = script_memory + idx;
++    data_peek_ex(*(uint8_t *)VM_REF_TO_PTR(FN_ARG0), *(uint16_t *)VM_REF_TO_PTR(FN_ARG1), *(uint16_t *)VM_REF_TO_PTR(FN_ARG2), A);
 +}
 +
 +void vm_data_save_ex(SCRIPT_CTX * THIS) OLDCALL BANKED {

--- a/plugins/Mico27/ConfigLoadSavePlugin/events/eventDataPeekByIndex.js
+++ b/plugins/Mico27/ConfigLoadSavePlugin/events/eventDataPeekByIndex.js
@@ -56,25 +56,29 @@ const fields = [
 
 const compile = (input, helpers) => {
 
-    const { _declareLocal, getVariableAlias, getNextLabel, _addComment, _ifConst, _setVariableConst, _label, _addNL, _stackPushConst, _callNative, _stackPop } = helpers;
-
-  const variableDestAlias = getVariableAlias(input.variableDest);
-  //const foundLabel = getNextLabel();
+    const { _declareLocal, getVariableAlias, getNextLabel, _addComment, _ifConst, _setVariableConst, _label, _addNL, _stackPushConst, _callNative, _stackPop, _isIndirectVariable, _setInd } = helpers;
+  
+  const variableAlias = getVariableAlias(input.variableDest);
+  let dest = variableAlias;
+  if (_isIndirectVariable(input.variableDest)) {
+    const dataResultRef = _declareLocal("data_result", 1, true);
+    dest = dataResultRef;
+  }
 
   _addComment(
-    `Store ${input.variableSource} from save slot ${input.saveSlot} into ${variableDestAlias}`
+    `Store ${input.variableSource} from save slot ${input.saveSlot} into ${variableAlias}`
   );
 
-  _stackPushConst(variableDestAlias);
+  _stackPushConst(dest);
   _stackPushConst(1);
   _stackPushConst(input.variableSource);
   _stackPushConst(input.saveSlot);
   _callNative("vm_data_peek_ex");
   _stackPop(4);
-  //_ifConst(".EQ", peekValueRef, 1, foundLabel, 0);
-  //_setVariableConst(input.variableDest, 0);
-  //_label(foundLabel);
-  _addNL();
+  
+  if (_isIndirectVariable(input.variableDest)) {
+    _setInd(variableAlias, dest);
+  }
 
 };
 

--- a/plugins/Mico27/ConfigLoadSavePlugin/plugin.json
+++ b/plugins/Mico27/ConfigLoadSavePlugin/plugin.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/Mico27/gbs-ConfigLoadSavePlugin",
   "description": "Allows configuration of the game saving structure.",
   "license": "MIT",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "gbsVersion": ">=4.3.0",
   "order": -1,
   "engineAltRules": [

--- a/plugins/Mico27/CopyRomDataToRamPlugin/engine/src/copy_rom_data_to_ram.c
+++ b/plugins/Mico27/CopyRomDataToRamPlugin/engine/src/copy_rom_data_to_ram.c
@@ -10,7 +10,9 @@ void copy_rom_data_to_ram(SCRIPT_CTX * THIS) OLDCALL BANKED {
     uint8_t rom_data_bank = *(uint8_t *) VM_REF_TO_PTR(FN_ARG0);
     uint8_t* rom_data_ptr = *(uint8_t**) VM_REF_TO_PTR(FN_ARG1);
     uint16_t rom_data_offset = *(int16_t*)VM_REF_TO_PTR(FN_ARG2);
-    uint16_t*  ram_data_ptr = &script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG3)];
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG3);
+    int16_t * ram_data_ptr;
+    if (idx < 0) ram_data_ptr = THIS->stack_ptr + idx - 4; else ram_data_ptr = script_memory + idx;
     uint16_t ram_data_offset = *(int16_t*)VM_REF_TO_PTR(FN_ARG4);
     size_t data_length = *(size_t*)VM_REF_TO_PTR(FN_ARG5);
     MemcpyBanked(ram_data_ptr + ram_data_offset, rom_data_ptr + rom_data_offset, data_length, rom_data_bank);

--- a/plugins/Mico27/CopyRomDataToRamPlugin/events/eventCopyRomDataToRam.js
+++ b/plugins/Mico27/CopyRomDataToRamPlugin/events/eventCopyRomDataToRam.js
@@ -50,28 +50,30 @@ export const fields = [
 ];
 
 export const compile = (input, helpers) => {
-  const { _callNative, _stackPushConst, _stackPush, _stackPop, _addComment, _declareLocal, variableSetToScriptValue, getVariableAlias } = helpers;
-
-  const tmp0 = _declareLocal("tmp_0", 1, true);
-  const tmp1 = _declareLocal("tmp_1", 1, true);
-  const tmp2 = _declareLocal("tmp_2", 1, true);
-
-  variableSetToScriptValue(tmp0, input.rom_data_offset);
-  variableSetToScriptValue(tmp1, input.ram_data_offset);
-  variableSetToScriptValue(tmp2, input.data_length);
+  const { _callNative, _stackPushConst, _isIndirectVariable, _stackPop, _addComment, _declareLocal, _setInd, getVariableAlias, _stackPushScriptValue } = helpers;
 
   const variableAlias = getVariableAlias(input.ram_data_ptr);
+  let dest = variableAlias;
+  if (_isIndirectVariable(input.ram_data_ptr)) {
+    const ram_result = _declareLocal("ram_result", 1, true);
+    dest = ram_result;
+  }
 
   _addComment("Copy ROM data to variable");
 
-  _stackPush(tmp2);
-  _stackPush(tmp1);
-  _stackPushConst(variableAlias);
-  _stackPush(tmp0);
+  _stackPushScriptValue(input.data_length);
+  _stackPushScriptValue(input.ram_data_offset);
+  _stackPushConst(dest);
+  _stackPushScriptValue(input.rom_data_offset);
   _stackPushConst(`_${input.rom_data_symbol}`);
   _stackPushConst(`___bank_${input.rom_data_symbol}`);
 
   _callNative("copy_rom_data_to_ram");
+  
   _stackPop(6);
+  
+  if (_isIndirectVariable(input.ram_data_ptr)) {
+    _setInd(variableAlias, dest);
+  }
 
 };

--- a/plugins/Mico27/CopyRomDataToRamPlugin/plugin.json
+++ b/plugins/Mico27/CopyRomDataToRamPlugin/plugin.json
@@ -5,6 +5,6 @@
   "url": "https://github.com/Mico27/gbs-copyRomDataToRamPlugin",
   "description": "Allows reading custom ROM data to store in variables",
   "license": "MIT",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "gbsVersion": ">=4.3.0"
 }

--- a/plugins/Mico27/EditActorActiveIndexPlugin/engine/src/core/actor_active_index.c
+++ b/plugins/Mico27/EditActorActiveIndexPlugin/engine/src/core/actor_active_index.c
@@ -48,6 +48,9 @@ void set_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
 
 void get_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
     UBYTE actor_idx = *(uint8_t *)VM_REF_TO_PTR(FN_ARG0);
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG1);
+    int16_t * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 2; else A = script_memory + idx;
     actor_t * actor = actors + actor_idx;
     if (CHK_FLAG(actor->flags, ACTOR_FLAG_ACTIVE)){
         actor_t * target_actor = actors_active_head;
@@ -60,7 +63,7 @@ void get_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
             active_idx++;
             target_actor = target_actor->next;
         }
-        script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG1)] = active_idx;
+        *A = active_idx;
     }
 }
 

--- a/plugins/Mico27/EditActorActiveIndexPlugin/engineAlt/Scr/src/core/actor_active_index.c
+++ b/plugins/Mico27/EditActorActiveIndexPlugin/engineAlt/Scr/src/core/actor_active_index.c
@@ -48,6 +48,9 @@ void set_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
 
 void get_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
     UBYTE actor_idx = *(uint8_t *)VM_REF_TO_PTR(FN_ARG0);
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG1);
+    int16_t * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 2; else A = script_memory + idx;
     actor_t * actor = actors + actor_idx;
     if (CHK_FLAG(actor->flags, ACTOR_FLAG_ACTIVE)){
         actor_t * target_actor = actors_active_head;
@@ -60,7 +63,7 @@ void get_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
             active_idx++;
             target_actor = target_actor->next;
         }
-        script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG1)] = active_idx;
+        *A = active_idx;
     }
 }
 

--- a/plugins/Mico27/EditActorActiveIndexPlugin/engineAlt/Scr_Sp/src/core/actor_active_index.c
+++ b/plugins/Mico27/EditActorActiveIndexPlugin/engineAlt/Scr_Sp/src/core/actor_active_index.c
@@ -48,6 +48,9 @@ void set_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
 
 void get_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
     UBYTE actor_idx = *(uint8_t *)VM_REF_TO_PTR(FN_ARG0);
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG1);
+    int16_t * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 2; else A = script_memory + idx;
     actor_t * actor = actors + actor_idx;
     if (CHK_FLAG(actor->flags, ACTOR_FLAG_ACTIVE)){
         actor_t * target_actor = actors_active_head;
@@ -60,7 +63,7 @@ void get_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
             active_idx++;
             target_actor = target_actor->next;
         }
-        script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG1)] = active_idx;
+        *A = active_idx;
     }
 }
 

--- a/plugins/Mico27/EditActorActiveIndexPlugin/engineAlt/Sp/src/core/actor_active_index.c
+++ b/plugins/Mico27/EditActorActiveIndexPlugin/engineAlt/Sp/src/core/actor_active_index.c
@@ -48,6 +48,9 @@ void set_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
 
 void get_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
     UBYTE actor_idx = *(uint8_t *)VM_REF_TO_PTR(FN_ARG0);
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG1);
+    int16_t * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 2; else A = script_memory + idx;
     actor_t * actor = actors + actor_idx;
     if (CHK_FLAG(actor->flags, ACTOR_FLAG_ACTIVE)){
         actor_t * target_actor = actors_active_head;
@@ -60,7 +63,7 @@ void get_actor_active_index(SCRIPT_CTX * THIS) OLDCALL BANKED {
             active_idx++;
             target_actor = target_actor->next;
         }
-        script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG1)] = active_idx;
+        *A = active_idx;
     }
 }
 

--- a/plugins/Mico27/EditActorActiveIndexPlugin/events/eventGetActorActiveIndex.js
+++ b/plugins/Mico27/EditActorActiveIndexPlugin/events/eventGetActorActiveIndex.js
@@ -26,20 +26,28 @@ export const fields = [
 ];
 
 export const compile = (input, helpers) => {
-  const { _callNative, _stackPush, _stackPop, _addComment, _declareLocal, setActorId, getVariableAlias, _stackPushConst } = helpers;
-
-  const tmp0 = _declareLocal("tmp0", 1, true);
-
-  setActorId(tmp0, input.actorId);
+  const { _callNative, _stackPush, _stackPop, _addComment, _declareLocal, setActorId, getVariableAlias, _stackPushConst, _isIndirectVariable, _setInd } = helpers;
 
   const variableAlias = getVariableAlias(input.variable);
+  let dest = variableAlias;
+  if (_isIndirectVariable(input.variable)) {
+    const index_result = _declareLocal("index_result", 1, true);
+    dest = index_result;
+  }
+  
+  const tmp0 = _declareLocal("tmp0", 1, true);
+  setActorId(tmp0, input.actorId);
 
   _addComment("Get actor active index");
 
-  _stackPushConst(variableAlias);
+  _stackPushConst(dest);
   _stackPush(tmp0);
 
   _callNative("get_actor_active_index");
   _stackPop(2);
+  
+  if (_isIndirectVariable(input.variable)) {
+    _setInd(variableAlias, dest);
+  }
 
 };

--- a/plugins/Mico27/EditActorActiveIndexPlugin/plugin.json
+++ b/plugins/Mico27/EditActorActiveIndexPlugin/plugin.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/Mico27/gbs-EditActorActiveIndexPlugin",
   "description": "Allows editing the order of the actors in the active actors list used for rendering/OAM order. This plugins allow sorting actor depending on their vertical position and enable flickering for when more than 10 sprite tile are on a given scanline or then the 40 sprite tile on-screen limit is exceeded.",
   "license": "MIT",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "gbsVersion": ">=4.3.0",
   "order": -1,
   "engineAltRules": [

--- a/plugins/Mico27/FadeStreetPlugin/engineAlt/Scr_M/src/core/data_manager.c.patch
+++ b/plugins/Mico27/FadeStreetPlugin/engineAlt/Scr_M/src/core/data_manager.c.patch
@@ -2,3 +2,56 @@ Index: src\core\data_manager.c
 ===================================================================
 --- src\core\data_manager.c
 +++ src\core\data_manager.c
+@@ -165,37 +165,14 @@
+ }
+ 
+ UBYTE do_load_palette(palette_entry_t * dest, const palette_t * palette, UBYTE bank) BANKED {
+     UBYTE mask = ReadBankedUBYTE(&palette->mask, bank);
+-    palette_entry_t * sour = palette->cgb_palette;
+-    for (UBYTE i = mask; (i); i >>= 1, dest++) {
+-        if ((i & 1) == 0) continue;
+-        MemcpyBanked(dest, sour, sizeof(palette_entry_t), bank);
+-        sour++;
+-    }
++    dest;
++    palette;
++    bank;
+     return mask;
+ }
+ 
+-inline void load_bkg_palette(const palette_t * palette, UBYTE bank) {
+-    UBYTE mask = do_load_palette(BkgPalette, palette, bank);
+-    DMG_palette[0] = ReadBankedUBYTE(palette->palette, bank);
+-#ifdef SGB
+-    if (_is_SGB) {
+-        UBYTE sgb_palettes = SGB_PALETTES_NONE;
+-        if (mask & 0b00110000) sgb_palettes |= SGB_PALETTES_01;
+-        if (mask & 0b11000000) sgb_palettes |= SGB_PALETTES_23;
+-        SGBTransferPalettes(sgb_palettes);
+-    }
+-#endif
+-}
+-
+-inline void load_sprite_palette(const palette_t * palette, UBYTE bank) {
+-    do_load_palette(SprPalette, palette, bank);
+-    UWORD data = ReadBankedUWORD(palette->palette, bank);
+-    DMG_palette[1] = (UBYTE)data;
+-    DMG_palette[2] = (UBYTE)(data >> 8);
+-}
+-
+ UBYTE load_scene(const scene_t * scene, UBYTE bank, UBYTE init_data) BANKED {
+     UBYTE i;
+     scene_t scn;
+ 
+@@ -221,11 +198,8 @@
+ 
+     // Load background + tiles
+     load_background(scn.background.ptr, scn.background.bank);
+ 
+-    load_bkg_palette(scn.palette.ptr, scn.palette.bank);
+-    load_sprite_palette(scn.sprite_palette.ptr, scn.sprite_palette.bank);
+-
+     // Copy parallax settings
+     memcpy(&parallax_rows, &scn.parallax_rows, sizeof(parallax_rows));
+     if (scn.parallax_rows[0].next_y == 0) {
+         scene_LCD_type = (scene_type == SCENE_TYPE_LOGO) ? LCD_fullscreen : LCD_simple;

--- a/plugins/Mico27/FadeStreetPlugin/engineAlt/Scr_M_Sce/src/core/data_manager.c.patch
+++ b/plugins/Mico27/FadeStreetPlugin/engineAlt/Scr_M_Sce/src/core/data_manager.c.patch
@@ -2,3 +2,56 @@ Index: src\core\data_manager.c
 ===================================================================
 --- src\core\data_manager.c
 +++ src\core\data_manager.c
+@@ -168,37 +168,14 @@
+ }
+ 
+ UBYTE do_load_palette(palette_entry_t * dest, const palette_t * palette, UBYTE bank) BANKED {
+     UBYTE mask = ReadBankedUBYTE(&palette->mask, bank);
+-    palette_entry_t * sour = palette->cgb_palette;
+-    for (UBYTE i = mask; (i); i >>= 1, dest++) {
+-        if ((i & 1) == 0) continue;
+-        MemcpyBanked(dest, sour, sizeof(palette_entry_t), bank);
+-        sour++;
+-    }
++    dest;
++    palette;
++    bank;
+     return mask;
+ }
+ 
+-inline void load_bkg_palette(const palette_t * palette, UBYTE bank) {
+-    UBYTE mask = do_load_palette(BkgPalette, palette, bank);
+-    DMG_palette[0] = ReadBankedUBYTE(palette->palette, bank);
+-#ifdef SGB
+-    if (_is_SGB) {
+-        UBYTE sgb_palettes = SGB_PALETTES_NONE;
+-        if (mask & 0b00110000) sgb_palettes |= SGB_PALETTES_01;
+-        if (mask & 0b11000000) sgb_palettes |= SGB_PALETTES_23;
+-        SGBTransferPalettes(sgb_palettes);
+-    }
+-#endif
+-}
+-
+-inline void load_sprite_palette(const palette_t * palette, UBYTE bank) {
+-    do_load_palette(SprPalette, palette, bank);
+-    UWORD data = ReadBankedUWORD(palette->palette, bank);
+-    DMG_palette[1] = (UBYTE)data;
+-    DMG_palette[2] = (UBYTE)(data >> 8);
+-}
+-
+ UBYTE load_scene(const scene_t * scene, UBYTE bank, UBYTE init_data) BANKED {
+     UBYTE i;
+     scene_t scn;
+ 
+@@ -224,11 +201,8 @@
+ 
+     // Load background + tiles
+     load_background(scn.background.ptr, scn.background.bank);
+ 
+-    load_bkg_palette(scn.palette.ptr, scn.palette.bank);
+-    load_sprite_palette(scn.sprite_palette.ptr, scn.sprite_palette.bank);
+-
+     // Copy parallax settings
+     memcpy(&parallax_rows, &scn.parallax_rows, sizeof(parallax_rows));
+     if (scn.parallax_rows[0].next_y == 0) {
+         scene_LCD_type = (scene_type == SCENE_TYPE_LOGO) ? LCD_fullscreen : LCD_simple;

--- a/plugins/Mico27/FadeStreetPlugin/engineAlt/Scr_Sce/src/core/data_manager.c.patch
+++ b/plugins/Mico27/FadeStreetPlugin/engineAlt/Scr_Sce/src/core/data_manager.c.patch
@@ -2,3 +2,56 @@ Index: src\core\data_manager.c
 ===================================================================
 --- src\core\data_manager.c
 +++ src\core\data_manager.c
+@@ -167,37 +167,14 @@
+ }
+ 
+ UBYTE do_load_palette(palette_entry_t * dest, const palette_t * palette, UBYTE bank) BANKED {
+     UBYTE mask = ReadBankedUBYTE(&palette->mask, bank);
+-    palette_entry_t * sour = palette->cgb_palette;
+-    for (UBYTE i = mask; (i); i >>= 1, dest++) {
+-        if ((i & 1) == 0) continue;
+-        MemcpyBanked(dest, sour, sizeof(palette_entry_t), bank);
+-        sour++;
+-    }
++    dest;
++    palette;
++    bank;
+     return mask;
+ }
+ 
+-inline void load_bkg_palette(const palette_t * palette, UBYTE bank) {
+-    UBYTE mask = do_load_palette(BkgPalette, palette, bank);
+-    DMG_palette[0] = ReadBankedUBYTE(palette->palette, bank);
+-#ifdef SGB
+-    if (_is_SGB) {
+-        UBYTE sgb_palettes = SGB_PALETTES_NONE;
+-        if (mask & 0b00110000) sgb_palettes |= SGB_PALETTES_01;
+-        if (mask & 0b11000000) sgb_palettes |= SGB_PALETTES_23;
+-        SGBTransferPalettes(sgb_palettes);
+-    }
+-#endif
+-}
+-
+-inline void load_sprite_palette(const palette_t * palette, UBYTE bank) {
+-    do_load_palette(SprPalette, palette, bank);
+-    UWORD data = ReadBankedUWORD(palette->palette, bank);
+-    DMG_palette[1] = (UBYTE)data;
+-    DMG_palette[2] = (UBYTE)(data >> 8);
+-}
+-
+ UBYTE load_scene(const scene_t * scene, UBYTE bank, UBYTE init_data) BANKED {
+     UBYTE i;
+     scene_t scn;
+ 
+@@ -223,11 +200,8 @@
+ 
+     // Load background + tiles
+     load_background(scn.background.ptr, scn.background.bank);
+ 
+-    load_bkg_palette(scn.palette.ptr, scn.palette.bank);
+-    load_sprite_palette(scn.sprite_palette.ptr, scn.sprite_palette.bank);
+-
+     // Copy parallax settings
+     memcpy(&parallax_rows, &scn.parallax_rows, sizeof(parallax_rows));
+     if (scn.parallax_rows[0].next_y == 0) {
+         scene_LCD_type = (scene_type == SCENE_TYPE_LOGO) ? LCD_fullscreen : LCD_simple;

--- a/plugins/Mico27/FadeStreetPlugin/plugin.json
+++ b/plugins/Mico27/FadeStreetPlugin/plugin.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/Mico27/gbs-fadestreet",
   "description": "Toolset for animation color palettes and custom fading.",
   "license": "MIT",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "gbsVersion": ">=4.3.0",
   "order": -4,
   "engineAltRules": [

--- a/plugins/Mico27/MetaTilePlugin/engine/src/core/meta_tiles.c
+++ b/plugins/Mico27/MetaTilePlugin/engine/src/core/meta_tiles.c
@@ -127,7 +127,10 @@ void vm_reset_meta_tile(SCRIPT_CTX * THIS) OLDCALL BANKED {
 void vm_get_sram_tile_id_at_pos(SCRIPT_CTX * THIS) OLDCALL BANKED {
     uint8_t x = *(uint8_t *) VM_REF_TO_PTR(FN_ARG0);
     uint8_t y = *(uint8_t *) VM_REF_TO_PTR(FN_ARG1);
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG2)] = sram_map_data[METATILE_MAP_OFFSET(x, y)];
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG2);
+    int16_t * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 3; else A = script_memory + idx;
+    *A = sram_map_data[METATILE_MAP_OFFSET(x, y)];
 }
 
 void vm_replace_collision(SCRIPT_CTX * THIS) OLDCALL BANKED {
@@ -150,10 +153,13 @@ void vm_replace_collision(SCRIPT_CTX * THIS) OLDCALL BANKED {
 void vm_get_collision_at_pos(SCRIPT_CTX * THIS) OLDCALL BANKED {
     uint8_t x = *(uint8_t *) VM_REF_TO_PTR(FN_ARG0);
     uint8_t y = *(uint8_t *) VM_REF_TO_PTR(FN_ARG1);
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG2);
+    int16_t * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 3; else A = script_memory + idx;
 #if METATILE_SIZE == METATILE_SIZE_16
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG2)] = sram_collision_data[TILE_MAP_OFFSET(sram_map_data[METATILE_MAP_OFFSET(x, y)], x, y)];
+    *A = sram_collision_data[TILE_MAP_OFFSET(sram_map_data[METATILE_MAP_OFFSET(x, y)], x, y)];
 #else
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG2)] = sram_collision_data[sram_map_data[METATILE_MAP_OFFSET(x, y)]];
+    *A = sram_collision_data[sram_map_data[METATILE_MAP_OFFSET(x, y)]];
 #endif
 }
 
@@ -344,7 +350,7 @@ UBYTE metatile_overlap_at_intersection(rect16_t *bb, upoint16_t *offset) BANKED 
         left_side_checked = METATILE_TILE_WIDTH;
     }
     //check right
-    if (current_left_tile != current_right_tile && (current_right_tile > previous_right_tile)){
+    if (current_right_tile > previous_right_tile){
         tmp_tile = current_top_tile;
         while (tmp_tile <= current_bottom_tile){
             metatile_overlap_iteration++;
@@ -375,7 +381,7 @@ UBYTE metatile_overlap_at_intersection(rect16_t *bb, upoint16_t *offset) BANKED 
     }
 
     //Check bottom
-    if (current_top_tile != current_bottom_tile && (current_bottom_tile > previous_bottom_tile)){
+    if (current_bottom_tile > previous_bottom_tile){
         tmp_tile = current_left_tile + left_side_checked;
         while (tmp_tile <= (current_right_tile - right_side_checked)){
             metatile_overlap_iteration++;

--- a/plugins/Mico27/MetaTilePlugin/engineAlt/Scr/src/core/meta_tiles.c
+++ b/plugins/Mico27/MetaTilePlugin/engineAlt/Scr/src/core/meta_tiles.c
@@ -128,7 +128,10 @@ void vm_reset_meta_tile(SCRIPT_CTX * THIS) OLDCALL BANKED {
 void vm_get_sram_tile_id_at_pos(SCRIPT_CTX * THIS) OLDCALL BANKED {
     uint8_t x = *(uint8_t *) VM_REF_TO_PTR(FN_ARG0);
     uint8_t y = *(uint8_t *) VM_REF_TO_PTR(FN_ARG1);
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG2)] = sram_map_data[METATILE_MAP_OFFSET(x, y)];
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG2);
+    int16_t * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 3; else A = script_memory + idx;
+    *A = sram_map_data[METATILE_MAP_OFFSET(x, y)];
 }
 
 void vm_replace_collision(SCRIPT_CTX * THIS) OLDCALL BANKED {
@@ -151,10 +154,13 @@ void vm_replace_collision(SCRIPT_CTX * THIS) OLDCALL BANKED {
 void vm_get_collision_at_pos(SCRIPT_CTX * THIS) OLDCALL BANKED {
     uint8_t x = *(uint8_t *) VM_REF_TO_PTR(FN_ARG0);
     uint8_t y = *(uint8_t *) VM_REF_TO_PTR(FN_ARG1);
+    int16_t idx = *(int16_t*)VM_REF_TO_PTR(FN_ARG2);
+    int16_t * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 3; else A = script_memory + idx;
 #if METATILE_SIZE == METATILE_SIZE_16
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG2)] = sram_collision_data[TILE_MAP_OFFSET(sram_map_data[METATILE_MAP_OFFSET(x, y)], x, y)];
+    *A = sram_collision_data[TILE_MAP_OFFSET(sram_map_data[METATILE_MAP_OFFSET(x, y)], x, y)];
 #else
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG2)] = sram_collision_data[sram_map_data[METATILE_MAP_OFFSET(x, y)]];
+    *A = sram_collision_data[sram_map_data[METATILE_MAP_OFFSET(x, y)]];
 #endif
 }
 
@@ -345,7 +351,7 @@ UBYTE metatile_overlap_at_intersection(rect16_t *bb, upoint16_t *offset) BANKED 
         left_side_checked = METATILE_TILE_WIDTH;
     }
     //check right
-    if (current_left_tile != current_right_tile && (current_right_tile > previous_right_tile)){
+    if (current_right_tile > previous_right_tile){
         tmp_tile = current_top_tile;
         while (tmp_tile <= current_bottom_tile){
             metatile_overlap_iteration++;
@@ -376,7 +382,7 @@ UBYTE metatile_overlap_at_intersection(rect16_t *bb, upoint16_t *offset) BANKED 
     }
 
     //Check bottom
-    if (current_top_tile != current_bottom_tile && (current_bottom_tile > previous_bottom_tile)){
+    if (current_bottom_tile > previous_bottom_tile){
         tmp_tile = current_left_tile + left_side_checked;
         while (tmp_tile <= (current_right_tile - right_side_checked)){
             metatile_overlap_iteration++;

--- a/plugins/Mico27/MetaTilePlugin/events/eventGetMetaTileAtPosition.js
+++ b/plugins/Mico27/MetaTilePlugin/events/eventGetMetaTileAtPosition.js
@@ -37,16 +37,25 @@ export const fields = [
 
 export const compile = (input, helpers) => {
 
-  const { _callNative, _stackPushConst, _stackPop, _addComment, getVariableAlias, _stackPushScriptValue } = helpers;
-
+  const { _callNative, _stackPushConst, _stackPop, _addComment, getVariableAlias, _stackPushScriptValue, _isIndirectVariable, _declareLocal, _setInd } = helpers;
+  
   const variableAlias = getVariableAlias(input.output);
+  let dest = variableAlias;
+  if (_isIndirectVariable(input.output)) {
+    const metatile_result = _declareLocal("metatile_result", 1, true);
+    dest = metatile_result;
+  }
 
   _addComment("Get metatile at position");
 
-  _stackPushConst(variableAlias);
+  _stackPushConst(dest);
   _stackPushScriptValue(input.y);
   _stackPushScriptValue(input.x);
 
   _callNative("vm_get_sram_tile_id_at_pos");
   _stackPop(3);
+  
+  if (_isIndirectVariable(input.output)) {
+    _setInd(variableAlias, dest);
+  }
 };

--- a/plugins/Mico27/MetaTilePlugin/events/eventGetMetatTileCollisionAtPosition.js
+++ b/plugins/Mico27/MetaTilePlugin/events/eventGetMetatTileCollisionAtPosition.js
@@ -37,16 +37,25 @@ export const fields = [
 
 export const compile = (input, helpers) => {
 
-  const { _callNative, _stackPushConst, _stackPop, _addComment, getVariableAlias, _stackPushScriptValue } = helpers;
+  const { _callNative, _stackPushConst, _stackPop, _addComment, getVariableAlias, _stackPushScriptValue, _isIndirectVariable, _declareLocal, _setInd } = helpers;
 
   const variableAlias = getVariableAlias(input.output);
+  let dest = variableAlias;
+  if (_isIndirectVariable(input.output)) {
+    const collision_result = _declareLocal("collision_result", 1, true);
+    dest = collision_result;
+  }
 
   _addComment("Get metatile collision at position");
 
-  _stackPushConst(variableAlias);
+  _stackPushConst(dest);
   _stackPushScriptValue(input.y);
   _stackPushScriptValue(input.x);
 
   _callNative("vm_get_collision_at_pos");
   _stackPop(3);
+  
+  if (_isIndirectVariable(input.output)) {
+    _setInd(variableAlias, dest);
+  }
 };

--- a/plugins/Mico27/MetaTilePlugin/plugin.json
+++ b/plugins/Mico27/MetaTilePlugin/plugin.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/Mico27/gbs-MetatilePlugin",
   "description": "Integrates the concept of metatiles in gbstudio",
   "license": "MIT",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "gbsVersion": ">=4.3.0",
   "order": -12,
   "engineAltRules": [

--- a/plugins/Mico27/SceneStackExPlugin/engine/src/core/scene_stack_ex.c
+++ b/plugins/Mico27/SceneStackExPlugin/engine/src/core/scene_stack_ex.c
@@ -305,5 +305,8 @@ void vm_poll_stack_pop(SCRIPT_CTX * THIS) OLDCALL BANKED {
 }
 
 void vm_get_stack_size(SCRIPT_CTX * THIS) OLDCALL BANKED {
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG0)] = sizeof(scene_stacks_ex);
+    int16_t idx = *(int16_t *)VM_REF_TO_PTR(FN_ARG0);
+    UWORD * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 1; else A = script_memory + idx;
+    *A = sizeof(scene_stacks_ex);
 }

--- a/plugins/Mico27/SceneStackExPlugin/engineAlt/M/src/core/scene_stack_ex.c
+++ b/plugins/Mico27/SceneStackExPlugin/engineAlt/M/src/core/scene_stack_ex.c
@@ -344,5 +344,8 @@ void vm_poll_stack_pop(SCRIPT_CTX * THIS) OLDCALL BANKED {
 }
 
 void vm_get_stack_size(SCRIPT_CTX * THIS) OLDCALL BANKED {
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG0)] = sizeof(scene_stacks_ex);
+    int16_t idx = *(int16_t *)VM_REF_TO_PTR(FN_ARG0);
+    UWORD * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 1; else A = script_memory + idx;
+    *A = sizeof(scene_stacks_ex);
 }

--- a/plugins/Mico27/SceneStackExPlugin/engineAlt/Scr/src/core/scene_stack_ex.c
+++ b/plugins/Mico27/SceneStackExPlugin/engineAlt/Scr/src/core/scene_stack_ex.c
@@ -336,5 +336,8 @@ void vm_poll_stack_pop(SCRIPT_CTX * THIS) OLDCALL BANKED {
 }
 
 void vm_get_stack_size(SCRIPT_CTX * THIS) OLDCALL BANKED {
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG0)] = sizeof(scene_stacks_ex);
+    int16_t idx = *(int16_t *)VM_REF_TO_PTR(FN_ARG0);
+    UWORD * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 1; else A = script_memory + idx;
+    *A = sizeof(scene_stacks_ex);
 }

--- a/plugins/Mico27/SceneStackExPlugin/engineAlt/Scr_M/src/core/scene_stack_ex.c
+++ b/plugins/Mico27/SceneStackExPlugin/engineAlt/Scr_M/src/core/scene_stack_ex.c
@@ -375,5 +375,8 @@ void vm_poll_stack_pop(SCRIPT_CTX * THIS) OLDCALL BANKED {
 }
 
 void vm_get_stack_size(SCRIPT_CTX * THIS) OLDCALL BANKED {
-    script_memory[*(int16_t*)VM_REF_TO_PTR(FN_ARG0)] = sizeof(scene_stacks_ex);
+    int16_t idx = *(int16_t *)VM_REF_TO_PTR(FN_ARG0);
+    UWORD * A;
+    if (idx < 0) A = THIS->stack_ptr + idx - 1; else A = script_memory + idx;
+    *A = sizeof(scene_stacks_ex);
 }

--- a/plugins/Mico27/ScreenScrollPlugin/engine/engine.json
+++ b/plugins/Mico27/ScreenScrollPlugin/engine/engine.json
@@ -22,6 +22,26 @@
           "runtimeOnly": true
         },
         {
+          "key": "scene_transition_enabled",
+          "label": "Scene transition enabled",
+          "description": "Scene transition enabled",
+          "group": "Screen Scroll",
+          "type": "number",
+          "cType": "UBYTE",
+          "defaultValue": 0,
+          "runtimeOnly": true
+        },
+        {
+          "key": "is_transitioning_scene",
+          "label": "Is scene transitioning",
+          "description": "Is scene transitioning",
+          "group": "Screen Scroll",
+          "type": "number",
+          "cType": "UBYTE",
+          "defaultValue": 0,
+          "runtimeOnly": true
+        },
+        {
           "key": "scroll_right_margin",
           "label": "right side margin for huds aligned to the right",
           "description": "right side margin for huds aligned to the right",

--- a/plugins/Mico27/SetPaletteColorPlugin/engine/src/manage_palette_colors.c
+++ b/plugins/Mico27/SetPaletteColorPlugin/engine/src/manage_palette_colors.c
@@ -70,45 +70,50 @@ void set_palette_colors(SCRIPT_CTX * THIS) OLDCALL BANKED {
 
 void get_palette_colors(SCRIPT_CTX * THIS) OLDCALL BANKED {
     int16_t palettes = *(int16_t*)VM_REF_TO_PTR(FN_ARG0);
-    int16_t color0Var = *(int16_t*)VM_REF_TO_PTR(FN_ARG1);
-    int16_t color1Var = *(int16_t*)VM_REF_TO_PTR(FN_ARG2);
-    int16_t color2Var = *(int16_t*)VM_REF_TO_PTR(FN_ARG3);
-    int16_t color3Var = *(int16_t*)VM_REF_TO_PTR(FN_ARG4);
+    uint8_t palette_from_idx = palettes & 7;
+    int16_t * color0Var;
+    int16_t * color1Var;
+    int16_t * color2Var;
+    int16_t * color3Var;
+    int16_t idx = *(int16_t *)VM_REF_TO_PTR(FN_ARG1);
+    if (idx < 0) color0Var = THIS->stack_ptr + idx - 2; else color0Var = script_memory + idx;
+    idx = *(int16_t *)VM_REF_TO_PTR(FN_ARG2);
+    if (idx < 0) color1Var = THIS->stack_ptr + idx - 3; else color1Var = script_memory + idx;
+    idx = *(int16_t *)VM_REF_TO_PTR(FN_ARG3);
+    if (idx < 0) color2Var = THIS->stack_ptr + idx - 4; else color2Var = script_memory + idx;
+    idx = *(int16_t *)VM_REF_TO_PTR(FN_ARG4);
+    if (idx < 0) color3Var = THIS->stack_ptr + idx - 5; else color3Var = script_memory + idx;
 
-    UBYTE palette_from_idx = palettes & 7;
-    UBYTE is_sprite = (palettes >> 3) & 1;
-    UBYTE is_dmg = (palettes >> 4) & 1;
-
-    if (is_dmg) {
-        if (is_sprite){
+    if ((palettes >> 4) & 1) { //is dmg
+        if ((palettes >> 3) & 1){ //is sprite
             switch (palette_from_idx & 1) {
                 case 0:
-                    script_memory[color0Var] = ((DMG_palette[1] >> 2) & 3);
-                    script_memory[color1Var] = ((DMG_palette[1] >> 4) & 3);
-                    script_memory[color2Var] = ((DMG_palette[1] >> 6) & 3);
+                    *color0Var = ((DMG_palette[1] >> 2) & 3);
+                    *color1Var = ((DMG_palette[1] >> 4) & 3);
+                    *color2Var = ((DMG_palette[1] >> 6) & 3);
                     break;
                 case 1:
-                    script_memory[color0Var] = ((DMG_palette[2] >> 2) & 3);
-                    script_memory[color1Var] = ((DMG_palette[2] >> 4) & 3);
-                    script_memory[color2Var] = ((DMG_palette[2] >> 6) & 3);
+                    *color0Var = ((DMG_palette[2] >> 2) & 3);
+                    *color1Var = ((DMG_palette[2] >> 4) & 3);
+                    *color2Var = ((DMG_palette[2] >> 6) & 3);
                     break;
             }
         } else {
-            script_memory[color0Var] = ((DMG_palette[0]) & 3);
-            script_memory[color1Var] = ((DMG_palette[0] >> 2) & 3);
-            script_memory[color2Var] = ((DMG_palette[0] >> 4) & 3);
-            script_memory[color3Var] = ((DMG_palette[0] >> 6) & 3);
+            *color0Var = ((DMG_palette[0]) & 3);
+            *color1Var = ((DMG_palette[0] >> 2) & 3);
+            *color2Var = ((DMG_palette[0] >> 4) & 3);
+            *color3Var = ((DMG_palette[0] >> 6) & 3);
         }
     } else {
-        if (is_sprite){
-            script_memory[color0Var] = SprPalette[palette_from_idx].c1;
-            script_memory[color1Var] = SprPalette[palette_from_idx].c2;
-            script_memory[color2Var] = SprPalette[palette_from_idx].c3;
+        if ((palettes >> 3) & 1){ //is sprite
+            *color0Var = SprPalette[palette_from_idx].c1;
+            *color1Var = SprPalette[palette_from_idx].c2;
+            *color2Var = SprPalette[palette_from_idx].c3;
         } else {
-            script_memory[color0Var] = BkgPalette[palette_from_idx].c0;
-            script_memory[color1Var] = BkgPalette[palette_from_idx].c1;
-            script_memory[color2Var] = BkgPalette[palette_from_idx].c2;
-            script_memory[color3Var] = BkgPalette[palette_from_idx].c3;
+            *color0Var = BkgPalette[palette_from_idx].c0;
+            *color1Var = BkgPalette[palette_from_idx].c1;
+            *color2Var = BkgPalette[palette_from_idx].c2;
+            *color3Var = BkgPalette[palette_from_idx].c3;
         }
     }
 }

--- a/plugins/Mico27/SetPaletteColorPlugin/events/eventGetPaletteColors.js
+++ b/plugins/Mico27/SetPaletteColorPlugin/events/eventGetPaletteColors.js
@@ -124,7 +124,7 @@ export const fields = [
 ];
 
 export const compile = (input, helpers) => {
-  const { _callNative, _rpn, _stackPushConst, _stackPush, _stackPop, _addComment, _declareLocal, variableSetToScriptValue, getVariableAlias } = helpers;
+  const { _callNative, _rpn, _stackPushConst, _stackPush, _stackPop, _addComment, _declareLocal, variableSetToScriptValue, getVariableAlias, _isIndirectVariable, _setInd } = helpers;
   const {is_gbc, is_sprite} = input;
 
 
@@ -132,7 +132,7 @@ export const compile = (input, helpers) => {
 
   variableSetToScriptValue(tmp_palette_idx, input.palette_idx);
 
-  _addComment("Set colors of a palette");
+  _addComment("Get colors of a palette");
 
   _rpn()  .ref(tmp_palette_idx)  // ((tmp_palette_idx) & 7)
           .int16((is_sprite)? 8: 0)
@@ -142,18 +142,57 @@ export const compile = (input, helpers) => {
           .refSet(tmp_palette_idx)
           .stop();
 
-    const color0Alias = getVariableAlias(input.color0);
-    const color1Alias = getVariableAlias(input.color1);
-    const color2Alias = getVariableAlias(input.color2);
-    const color3Alias = (!is_sprite)? getVariableAlias(input.color3): 0;
 
-  _stackPushConst(color3Alias);
-  _stackPushConst(color2Alias);
-  _stackPushConst(color1Alias);
-  _stackPushConst(color0Alias);
+  const color0Alias = getVariableAlias(input.color0);
+  let color0Dest = color0Alias;
+  if (_isIndirectVariable(input.color0)) {
+    const color0_result = _declareLocal("color0_result", 1, true);
+    color0Dest = color0_result;
+  }
+  
+  const color1Alias = getVariableAlias(input.color1);
+  let color1Dest = color1Alias;
+  if (_isIndirectVariable(input.color1)) {
+    const color1_result = _declareLocal("color1_result", 1, true);
+    color1Dest = color1_result;
+  }
+  
+  const color2Alias = getVariableAlias(input.color2);
+  let color2Dest = color2Alias;
+  if (_isIndirectVariable(input.color1)) {
+    const color2_result = _declareLocal("color2_result", 1, true);
+    color2Dest = color2_result;
+  }
+  
+  const color3Alias = (!is_sprite)? getVariableAlias(input.color3): 0;
+  let color3Dest = color3Alias;
+  if (!is_sprite && _isIndirectVariable(input.color3)) {
+    const color3_result = _declareLocal("color3_result", 1, true);
+    color3Dest = color3_result;
+  }
+
+  _stackPushConst(color3Dest);
+  _stackPushConst(color2Dest);
+  _stackPushConst(color1Dest);
+  _stackPushConst(color0Dest);
   _stackPush(tmp_palette_idx);
 
   _callNative("get_palette_colors");
   _stackPop(5);
 
+  if (_isIndirectVariable(input.color0)) {
+    _setInd(color0Alias, color0Dest);
+  }
+  
+  if (_isIndirectVariable(input.color1)) {
+    _setInd(color1Alias, color1Dest);
+  }
+  
+  if (_isIndirectVariable(input.color2)) {
+    _setInd(color2Alias, color2Dest);
+  }
+  
+  if (!is_sprite && _isIndirectVariable(input.color3)) {
+    _setInd(color3Alias, color3Dest);
+  }
 };

--- a/plugins/Mico27/SpritesheetChangeBufferPlugin/engineAlt/Scr_M_F/src/core/data_manager.c.patch
+++ b/plugins/Mico27/SpritesheetChangeBufferPlugin/engineAlt/Scr_M_F/src/core/data_manager.c.patch
@@ -2,60 +2,7 @@ Index: src\core\data_manager.c
 ===================================================================
 --- src\core\data_manager.c
 +++ src\core\data_manager.c
-@@ -165,37 +165,14 @@
- }
- 
- UBYTE do_load_palette(palette_entry_t * dest, const palette_t * palette, UBYTE bank) BANKED {
-     UBYTE mask = ReadBankedUBYTE(&palette->mask, bank);
--    palette_entry_t * sour = palette->cgb_palette;
--    for (UBYTE i = mask; (i); i >>= 1, dest++) {
--        if ((i & 1) == 0) continue;
--        MemcpyBanked(dest, sour, sizeof(palette_entry_t), bank);
--        sour++;
--    }
-+    dest;
-+    palette;
-+    bank;
-     return mask;
- }
- 
--inline void load_bkg_palette(const palette_t * palette, UBYTE bank) {
--    UBYTE mask = do_load_palette(BkgPalette, palette, bank);
--    DMG_palette[0] = ReadBankedUBYTE(palette->palette, bank);
--#ifdef SGB
--    if (_is_SGB) {
--        UBYTE sgb_palettes = SGB_PALETTES_NONE;
--        if (mask & 0b00110000) sgb_palettes |= SGB_PALETTES_01;
--        if (mask & 0b11000000) sgb_palettes |= SGB_PALETTES_23;
--        SGBTransferPalettes(sgb_palettes);
--    }
--#endif
--}
--
--inline void load_sprite_palette(const palette_t * palette, UBYTE bank) {
--    do_load_palette(SprPalette, palette, bank);
--    UWORD data = ReadBankedUWORD(palette->palette, bank);
--    DMG_palette[1] = (UBYTE)data;
--    DMG_palette[2] = (UBYTE)(data >> 8);
--}
--
- UBYTE load_scene(const scene_t * scene, UBYTE bank, UBYTE init_data) BANKED {
-     UBYTE i;
-     scene_t scn;
- 
-@@ -221,11 +198,8 @@
- 
-     // Load background + tiles
-     load_background(scn.background.ptr, scn.background.bank);
- 
--    load_bkg_palette(scn.palette.ptr, scn.palette.bank);
--    load_sprite_palette(scn.sprite_palette.ptr, scn.sprite_palette.bank);
--
-     // Copy parallax settings
-     memcpy(&parallax_rows, &scn.parallax_rows, sizeof(parallax_rows));
-     if (scn.parallax_rows[0].next_y == 0) {
-         scene_LCD_type = (scene_type == SCENE_TYPE_LOGO) ? LCD_fullscreen : LCD_simple;
-@@ -245,10 +219,17 @@
+@@ -219,10 +219,17 @@
              allocated_sprite_tiles = player_sprite_len;
          } else {
      #endif
@@ -74,7 +21,7 @@ Index: src\core\data_manager.c
              load_bounds(scn.player_sprite.ptr, scn.player_sprite.bank, &PLAYER.bounds);
      #ifdef DISABLE_PLAYER_SPRITE_LOAD_ON_TRANSITION
          }
-@@ -298,10 +279,11 @@
+@@ -272,10 +279,11 @@
              for (i = actors_len - 1; i != 0; i--, actor++) {
                  if (actor->reserve_tiles) {
                      // exclusive sprites allocated separately to avoid overwriting if modified

--- a/plugins/Mico27/SpritesheetChangeBufferPlugin/engineAlt/Scr_M_Sce_F/src/core/data_manager.c.patch
+++ b/plugins/Mico27/SpritesheetChangeBufferPlugin/engineAlt/Scr_M_Sce_F/src/core/data_manager.c.patch
@@ -2,60 +2,7 @@ Index: src\core\data_manager.c
 ===================================================================
 --- src\core\data_manager.c
 +++ src\core\data_manager.c
-@@ -168,37 +168,14 @@
- }
- 
- UBYTE do_load_palette(palette_entry_t * dest, const palette_t * palette, UBYTE bank) BANKED {
-     UBYTE mask = ReadBankedUBYTE(&palette->mask, bank);
--    palette_entry_t * sour = palette->cgb_palette;
--    for (UBYTE i = mask; (i); i >>= 1, dest++) {
--        if ((i & 1) == 0) continue;
--        MemcpyBanked(dest, sour, sizeof(palette_entry_t), bank);
--        sour++;
--    }
-+    dest;
-+    palette;
-+    bank;
-     return mask;
- }
- 
--inline void load_bkg_palette(const palette_t * palette, UBYTE bank) {
--    UBYTE mask = do_load_palette(BkgPalette, palette, bank);
--    DMG_palette[0] = ReadBankedUBYTE(palette->palette, bank);
--#ifdef SGB
--    if (_is_SGB) {
--        UBYTE sgb_palettes = SGB_PALETTES_NONE;
--        if (mask & 0b00110000) sgb_palettes |= SGB_PALETTES_01;
--        if (mask & 0b11000000) sgb_palettes |= SGB_PALETTES_23;
--        SGBTransferPalettes(sgb_palettes);
--    }
--#endif
--}
--
--inline void load_sprite_palette(const palette_t * palette, UBYTE bank) {
--    do_load_palette(SprPalette, palette, bank);
--    UWORD data = ReadBankedUWORD(palette->palette, bank);
--    DMG_palette[1] = (UBYTE)data;
--    DMG_palette[2] = (UBYTE)(data >> 8);
--}
--
- UBYTE load_scene(const scene_t * scene, UBYTE bank, UBYTE init_data) BANKED {
-     UBYTE i;
-     scene_t scn;
- 
-@@ -224,11 +201,8 @@
- 
-     // Load background + tiles
-     load_background(scn.background.ptr, scn.background.bank);
- 
--    load_bkg_palette(scn.palette.ptr, scn.palette.bank);
--    load_sprite_palette(scn.sprite_palette.ptr, scn.sprite_palette.bank);
--
-     // Copy parallax settings
-     memcpy(&parallax_rows, &scn.parallax_rows, sizeof(parallax_rows));
-     if (scn.parallax_rows[0].next_y == 0) {
-         scene_LCD_type = (scene_type == SCENE_TYPE_LOGO) ? LCD_fullscreen : LCD_simple;
-@@ -248,10 +222,17 @@
+@@ -222,10 +222,17 @@
              allocated_sprite_tiles = player_sprite_len;
          } else {
      #endif
@@ -74,7 +21,7 @@ Index: src\core\data_manager.c
                  load_animations(scn.player_sprite.ptr, scn.player_sprite.bank, ANIM_SET_DEFAULT, PLAYER.animations);
                  load_bounds(scn.player_sprite.ptr, scn.player_sprite.bank, &PLAYER.bounds);
              }
-@@ -303,10 +284,11 @@
+@@ -277,10 +284,11 @@
              for (i = actors_len - 1; i != 0; i--, actor++) {
                  if (actor->reserve_tiles) {
                      // exclusive sprites allocated separately to avoid overwriting if modified
@@ -87,7 +34,7 @@ Index: src\core\data_manager.c
                      // resolve and set base_tile for each actor
                      UBYTE idx = IndexOfFarPtr(scn.sprites.ptr, scn.sprites.bank, sprites_len, &actor->sprite);
                      actor->base_tile = (idx < sprites_len) ? scene_sprites_base_tiles[idx] : 0;
-@@ -355,12 +337,10 @@
+@@ -329,12 +337,10 @@
      if (triggers_len != 0) {
          MemcpyBanked(&triggers, scn.triggers.ptr, sizeof(trigger_t) * triggers_len, scn.triggers.bank);
      }

--- a/plugins/Mico27/SpritesheetChangeBufferPlugin/engineAlt/Scr_Sce_F/src/core/data_manager.c.patch
+++ b/plugins/Mico27/SpritesheetChangeBufferPlugin/engineAlt/Scr_Sce_F/src/core/data_manager.c.patch
@@ -2,60 +2,7 @@ Index: src\core\data_manager.c
 ===================================================================
 --- src\core\data_manager.c
 +++ src\core\data_manager.c
-@@ -167,37 +167,14 @@
- }
- 
- UBYTE do_load_palette(palette_entry_t * dest, const palette_t * palette, UBYTE bank) BANKED {
-     UBYTE mask = ReadBankedUBYTE(&palette->mask, bank);
--    palette_entry_t * sour = palette->cgb_palette;
--    for (UBYTE i = mask; (i); i >>= 1, dest++) {
--        if ((i & 1) == 0) continue;
--        MemcpyBanked(dest, sour, sizeof(palette_entry_t), bank);
--        sour++;
--    }
-+    dest;
-+    palette;
-+    bank;
-     return mask;
- }
- 
--inline void load_bkg_palette(const palette_t * palette, UBYTE bank) {
--    UBYTE mask = do_load_palette(BkgPalette, palette, bank);
--    DMG_palette[0] = ReadBankedUBYTE(palette->palette, bank);
--#ifdef SGB
--    if (_is_SGB) {
--        UBYTE sgb_palettes = SGB_PALETTES_NONE;
--        if (mask & 0b00110000) sgb_palettes |= SGB_PALETTES_01;
--        if (mask & 0b11000000) sgb_palettes |= SGB_PALETTES_23;
--        SGBTransferPalettes(sgb_palettes);
--    }
--#endif
--}
--
--inline void load_sprite_palette(const palette_t * palette, UBYTE bank) {
--    do_load_palette(SprPalette, palette, bank);
--    UWORD data = ReadBankedUWORD(palette->palette, bank);
--    DMG_palette[1] = (UBYTE)data;
--    DMG_palette[2] = (UBYTE)(data >> 8);
--}
--
- UBYTE load_scene(const scene_t * scene, UBYTE bank, UBYTE init_data) BANKED {
-     UBYTE i;
-     scene_t scn;
- 
-@@ -223,11 +200,8 @@
- 
-     // Load background + tiles
-     load_background(scn.background.ptr, scn.background.bank);
- 
--    load_bkg_palette(scn.palette.ptr, scn.palette.bank);
--    load_sprite_palette(scn.sprite_palette.ptr, scn.sprite_palette.bank);
--
-     // Copy parallax settings
-     memcpy(&parallax_rows, &scn.parallax_rows, sizeof(parallax_rows));
-     if (scn.parallax_rows[0].next_y == 0) {
-         scene_LCD_type = (scene_type == SCENE_TYPE_LOGO) ? LCD_fullscreen : LCD_simple;
-@@ -247,10 +221,17 @@
+@@ -221,10 +221,17 @@
              allocated_sprite_tiles = player_sprite_len;
          } else {
      #endif
@@ -74,7 +21,7 @@ Index: src\core\data_manager.c
                  load_animations(scn.player_sprite.ptr, scn.player_sprite.bank, ANIM_SET_DEFAULT, PLAYER.animations);
                  load_bounds(scn.player_sprite.ptr, scn.player_sprite.bank, &PLAYER.bounds);
              }
-@@ -302,10 +283,11 @@
+@@ -276,10 +283,11 @@
              for (i = actors_len - 1; i != 0; i--, actor++) {
                  if (actor->reserve_tiles) {
                      // exclusive sprites allocated separately to avoid overwriting if modified
@@ -87,7 +34,7 @@ Index: src\core\data_manager.c
                      // resolve and set base_tile for each actor
                      UBYTE idx = IndexOfFarPtr(scn.sprites.ptr, scn.sprites.bank, sprites_len, &actor->sprite);
                      actor->base_tile = (idx < sprites_len) ? scene_sprites_base_tiles[idx] : 0;
-@@ -354,11 +336,9 @@
+@@ -328,11 +336,9 @@
      if (triggers_len != 0) {
          MemcpyBanked(&triggers, scn.triggers.ptr, sizeof(trigger_t) * triggers_len, scn.triggers.bank);
      }

--- a/plugins/Mico27/SubmappingExPlugin/engine/src/copy_scene_parts.c
+++ b/plugins/Mico27/SubmappingExPlugin/engine/src/copy_scene_parts.c
@@ -52,8 +52,8 @@ void copy_background_submap_to_overlay_base(SCRIPT_CTX * THIS) OLDCALL BANKED {
     UBYTE source_y = (bkg_pos >> 8) & 0xFF;
     UBYTE dest_x = dest_pos & 0xFF;
     UBYTE dest_y = (dest_pos >> 8) & 0xFF;
-    UBYTE width = (wh & 0xFF) & 31;
-    UBYTE height = ((wh >> 8) & 0xFF) & 31;
+    UBYTE width = (wh & 0xFF);
+    UBYTE height = ((wh >> 8) & 0xFF);
 
     scene_t scn;
     MemcpyBanked(&scn, scene_ptr, sizeof(scn), scene_bank);
@@ -85,8 +85,8 @@ void copy_background_submap_to_background(SCRIPT_CTX * THIS) OLDCALL BANKED {
     uint8_t source_y = *(int8_t*)VM_REF_TO_PTR(FN_ARG1);
     uint8_t dest_x = *(int8_t*)VM_REF_TO_PTR(FN_ARG2);
     uint8_t dest_y = *(int8_t*)VM_REF_TO_PTR(FN_ARG3);
-    uint8_t width = *(int8_t*)VM_REF_TO_PTR(FN_ARG4) & 31;
-    uint8_t height = *(int8_t*)VM_REF_TO_PTR(FN_ARG5) & 31;
+    uint8_t width = *(int8_t*)VM_REF_TO_PTR(FN_ARG4);
+    uint8_t height = *(int8_t*)VM_REF_TO_PTR(FN_ARG5);
     uint8_t scene_bank = *(uint8_t *) VM_REF_TO_PTR(FN_ARG6);
     const scene_t * scene_ptr = *(scene_t **) VM_REF_TO_PTR(FN_ARG7);
     scene_t scn;
@@ -125,8 +125,8 @@ void copy_background_submap_to_background_base(SCRIPT_CTX * THIS) OLDCALL BANKED
     UBYTE source_y = (bkg_pos >> 8) & 0xFF;
     UBYTE dest_x = dest_pos & 0xFF;
     UBYTE dest_y = (dest_pos >> 8) & 0xFF;
-    UBYTE width = (wh & 0xFF) & 31;
-    UBYTE height = ((wh >> 8) & 0xFF) & 31;
+    UBYTE width = (wh & 0xFF);
+    UBYTE height = ((wh >> 8) & 0xFF);
 
     scene_t scn;
     MemcpyBanked(&scn, scene_ptr, sizeof(scn), scene_bank);
@@ -165,8 +165,8 @@ void copy_background_submap_to_tileset(SCRIPT_CTX * THIS) OLDCALL BANKED {
     UBYTE source_y = (source_pos >> 8) & 0xFF;
     UBYTE dest_x = dest_pos & 0xFF;
     UBYTE dest_y = (dest_pos >> 8) & 0xFF;
-    UBYTE width = (wh & 0xFF) & 31;
-    UBYTE height = ((wh >> 8) & 0xFF) & 31;
+    UBYTE width = (wh & 0xFF);
+    UBYTE height = ((wh >> 8) & 0xFF);
     UBYTE overlay_x = overlay_pos & 0xFF;
     UBYTE overlay_y = (overlay_pos >> 8) & 0xFF;
 


### PR DESCRIPTION
- Added custom script parameters / stack support for the plugin's events that store data in variables (ex: Metatile's  get metatile at position and get metatile collision at position events)
- Fix fadestreet compatibility that had some missing modifications in some plugin combinations.