### PR TITLE
publish actorByIndexPlugin

### DIFF
--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorActivateByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorActivateByIndex.js
@@ -1,0 +1,30 @@
+export const id = "EVENT_ACTOR_ACTIVATE_BY_INDEX";
+export const name = "Actor Activate By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Activate actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to activate.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorActivate, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorActivate(actorRef);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorCollisionsDisableByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorCollisionsDisableByIndex.js
@@ -1,0 +1,31 @@
+export const id = "EVENT_ACTOR_COLLISIONS_DISABLE_BY_INDEX";
+export const name = "Actor Disable Collisions By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Disable collisions for actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to disable collisions for.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorSetCollisions, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorSetCollisions(false);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorCollisionsEnableByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorCollisionsEnableByIndex.js
@@ -1,0 +1,31 @@
+export const id = "EVENT_ACTOR_COLLISIONS_ENABLE_BY_INDEX";
+export const name = "Actor Enable Collisions By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Enable collisions for actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to enable collisions for.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorSetCollisions, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorSetCollisions(true);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorDeactivateByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorDeactivateByIndex.js
@@ -1,0 +1,30 @@
+export const id = "EVENT_ACTOR_DEACTIVATE_BY_INDEX";
+export const name = "Actor Deactivate By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Deactivate actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to deactivate.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorDeactivate, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorDeactivate(actorRef);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorEffectsByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorEffectsByIndex.js
@@ -1,0 +1,143 @@
+export const id = "EVENT_ACTOR_EFFECTS_BY_INDEX";
+export const name = "Actor Effects By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Effect ${fetchArg("effect")} on actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "effect",
+    label: "Effect",
+    description: "Visual effect to apply to the actor.",
+    type: "select",
+    options: [
+      ["flicker", "Flicker"],
+      ["splitIn", "Split In"],
+      ["splitOut", "Split Out"],
+    ],
+    defaultValue: "flicker",
+    width: "100%",
+  },
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to apply the effect to.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+    width: "100%",
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    conditions: [
+      {
+        key: "effect",
+        in: ["splitIn", "splitOut"],
+      },
+    ],
+    fields: [
+      {
+        key: "distance",
+        label: "Distance",
+        description: "Split distance.",
+        type: "number",
+        min: 1,
+        max: 80,
+        defaultValue: 20,
+        unitsField: "units",
+        unitsDefault: "pixels",
+        unitsAllowed: ["tiles", "pixels"],
+        width: "50%",
+      },
+      {
+        key: "speed",
+        label: "Speed",
+        description: "Split speed.",
+        type: "moveSpeed",
+        allowNone: false,
+        defaultValue: 2,
+        width: "50%",
+      },
+    ],
+  },
+  {
+    key: "time",
+    type: "number",
+    label: "Duration",
+    description: "Duration in seconds.",
+    min: 0,
+    max: 60,
+    step: 0.1,
+    defaultValue: 0.5,
+    unitsField: "timeUnits",
+    unitsDefault: "time",
+    unitsAllowed: ["time", "frames"],
+    conditions: [
+      {
+        key: "effect",
+        in: ["flicker"],
+      },
+      {
+        key: "timeUnits",
+        ne: "frames",
+      },
+    ],
+  },
+  {
+    key: "frames",
+    label: "Duration",
+    description: "Duration in frames.",
+    type: "number",
+    min: 0,
+    max: 3600,
+    width: "50%",
+    defaultValue: 30,
+    unitsField: "timeUnits",
+    unitsDefault: "time",
+    unitsAllowed: ["time", "frames"],
+    conditions: [
+      {
+        key: "effect",
+        in: ["flicker"],
+      },
+      {
+        key: "timeUnits",
+        eq: "frames",
+      },
+    ],
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorFXSplitIn, actorFXSplitOut, actorFXFlicker, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  if (input.effect === "splitIn") {
+    actorFXSplitIn(actorRef, input.distance, input.speed, input.units);
+    return;
+  }
+  if (input.effect === "splitOut") {
+    actorFXSplitOut(actorRef, input.distance, input.speed, input.units);
+    return;
+  }
+  if (input.effect === "flicker") {
+    let frames = 0;
+    if (input.timeUnits === "frames") {
+      frames = typeof input.frames === "number" ? input.frames : 30;
+    } else {
+      const seconds = typeof input.time === "number" ? input.time : 0.5;
+      frames = Math.ceil(seconds * 60);
+    }
+    actorFXFlicker(actorRef, frames);
+  }
+};
+
+export const waitUntilAfterInitFade = true;

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorEmoteByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorEmoteByIndex.js
@@ -1,0 +1,40 @@
+export const id = "EVENT_ACTOR_EMOTE_BY_INDEX";
+export const name = "Actor Emote By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_ACTIONS",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Emote ${fetchArg("emoteId")} on actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to show the emote on.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "emoteId",
+    label: "Emote",
+    description: "Emote to display.",
+    type: "emote",
+    defaultValue: "LAST_EMOTE",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorEmote, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorEmote(input.emoteId);
+};
+
+export const waitUntilAfterInitFade = true;

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorGetDirectionByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorGetDirectionByIndex.js
@@ -1,0 +1,39 @@
+export const id = "EVENT_ACTOR_GET_DIRECTION_BY_INDEX";
+export const name = "Actor Get Direction By Index";
+export const groups = ["EVENT_GROUP_ACTOR", "EVENT_GROUP_VARIABLES"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_VARIABLES",
+  EVENT_GROUP_VARIABLES: "EVENT_GROUP_ACTOR",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Get direction of actor ${fetchArg("actorIndex")} into ${fetchArg("direction")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to get the direction of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "direction",
+    label: "Variable",
+    description: "Variable to store the direction.",
+    type: "variable",
+    defaultValue: "LAST_VARIABLE",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorGetDirection, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorGetDirection(input.direction);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorGetIndexToVariable.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorGetIndexToVariable.js
@@ -1,0 +1,41 @@
+export const id = "EVENT_ACTOR_GET_INDEX_TO_VARIABLE";
+export const name = "Actor Get Index To Variable";
+export const groups = ["EVENT_GROUP_ACTOR", "EVENT_GROUP_VARIABLES"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_VARIABLES",
+  EVENT_GROUP_VARIABLES: "EVENT_GROUP_ACTOR",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Store index of actor ${fetchArg("actorId")} into ${fetchArg("variable")}`;
+};
+
+export const fields = [
+  {
+    key: "actorId",
+    label: "Actor",
+    description: "Actor whose scene index will be stored.",
+    type: "actor",
+    defaultValue: "$self$",
+  },
+  {
+    key: "variable",
+    label: "Variable",
+    description: "Variable to store the actor index in.",
+    type: "variable",
+    defaultValue: "LAST_VARIABLE",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { setActorId, getVariableAlias, _declareLocal, _isIndirectVariable, _setInd, _addComment } = helpers;
+  _addComment("Actor Get Index To Variable");
+  const variableAlias = getVariableAlias(input.variable);
+  if (_isIndirectVariable(input.variable)) {
+    const tmp = _declareLocal("act_idx_tmp", 1, true);
+    setActorId(tmp, input.actorId);
+    _setInd(variableAlias, tmp);
+  } else {
+    setActorId(variableAlias, input.actorId);
+  }
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorGetPositionByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorGetPositionByIndex.js
@@ -1,0 +1,59 @@
+export const id = "EVENT_ACTOR_GET_POSITION_BY_INDEX";
+export const name = "Actor Get Position By Index";
+export const groups = ["EVENT_GROUP_ACTOR", "EVENT_GROUP_VARIABLES"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_VARIABLES",
+  EVENT_GROUP_VARIABLES: "EVENT_GROUP_ACTOR",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Get position of actor ${fetchArg("actorIndex")} into ${fetchArg("vectorX")}, ${fetchArg("vectorY")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to get the position of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    type: "group",
+    fields: [
+      {
+        key: "vectorX",
+        type: "variable",
+        label: "X",
+        description: "Variable to store the X position.",
+        defaultValue: "LAST_VARIABLE",
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+      },
+      {
+        key: "vectorY",
+        type: "variable",
+        label: "Y",
+        description: "Variable to store the Y position.",
+        defaultValue: "LAST_VARIABLE",
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+      },
+    ],
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorGetPosition, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorGetPosition(input.vectorX, input.vectorY, input.units);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorHideByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorHideByIndex.js
@@ -1,0 +1,30 @@
+export const id = "EVENT_ACTOR_HIDE_BY_INDEX";
+export const name = "Actor Hide By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_VISIBILITY",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Hide actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to hide.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorHide, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorHide(actorRef);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorMoveCancelByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorMoveCancelByIndex.js
@@ -1,0 +1,31 @@
+export const id = "EVENT_ACTOR_MOVE_CANCEL_BY_INDEX";
+export const name = "Actor Move Cancel By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_MOVEMENT",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Cancel move for actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to cancel movement for.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorMoveCancel, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorMoveCancel();
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorMoveRelativeByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorMoveRelativeByIndex.js
@@ -1,0 +1,94 @@
+export const id = "EVENT_ACTOR_MOVE_RELATIVE_BY_INDEX";
+export const name = "Actor Move Relative By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_MOVEMENT",
+};
+
+export const autoLabel = (fetchArg, input) => {
+  const unitPostfix = input.units === "pixels" ? "px" : "";
+  return `Move actor ${fetchArg("actorIndex")} by ${fetchArg("x")}${unitPostfix}, ${fetchArg("y")}${unitPostfix}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to move.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    fields: [
+      {
+        key: "x",
+        label: "X",
+        description: "Relative X offset.",
+        type: "value",
+        min: -31,
+        max: 31,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+      {
+        key: "y",
+        label: "Y",
+        description: "Relative Y offset.",
+        type: "value",
+        min: -31,
+        max: 31,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+    ],
+  },
+  {
+    key: "collideWith",
+    label: "Collide With",
+    type: "togglebuttons",
+    options: [
+      ["walls", "Walls", "Walls"],
+      ["actors", "Actors", "Actors"],
+    ],
+    allowNone: true,
+    allowMultiple: true,
+    defaultValue: ["walls"],
+  },
+  {
+    key: "moveType",
+    label: "Move Type",
+    hideLabel: true,
+    type: "moveType",
+    defaultValue: "horizontal",
+    flexBasis: 35,
+    flexGrow: 0,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorMoveRelativeByScriptValues, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorMoveRelativeByScriptValues(
+    actorRef,
+    input.x,
+    input.y,
+    input.collideWith,
+    input.moveType,
+    input.units,
+    input.lockDirection,
+  );
+};
+
+export const waitUntilAfterInitFade = true;

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorMoveToByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorMoveToByIndex.js
@@ -1,0 +1,94 @@
+export const id = "EVENT_ACTOR_MOVE_TO_BY_INDEX";
+export const name = "Actor Move To By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_MOVEMENT",
+};
+
+export const autoLabel = (fetchArg, input) => {
+  const unitPostfix = input.units === "pixels" ? "px" : "";
+  return `Move actor ${fetchArg("actorIndex")} to ${fetchArg("x")}${unitPostfix}, ${fetchArg("y")}${unitPostfix}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to move.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    fields: [
+      {
+        key: "x",
+        label: "X",
+        description: "Target X position.",
+        type: "value",
+        min: 0,
+        max: 255,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+      {
+        key: "y",
+        label: "Y",
+        description: "Target Y position.",
+        type: "value",
+        min: 0,
+        max: 255,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+    ],
+  },
+  {
+    key: "collideWith",
+    label: "Collide With",
+    type: "togglebuttons",
+    options: [
+      ["walls", "Walls", "Walls"],
+      ["actors", "Actors", "Actors"],
+    ],
+    allowNone: true,
+    allowMultiple: true,
+    defaultValue: ["walls"],
+  },
+  {
+    key: "moveType",
+    label: "Move Type",
+    hideLabel: true,
+    type: "moveType",
+    defaultValue: "horizontal",
+    flexBasis: 35,
+    flexGrow: 0,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorMoveToScriptValues, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorMoveToScriptValues(
+    actorRef,
+    input.x,
+    input.y,
+    input.collideWith,
+    input.moveType,
+    input.units,
+    input.lockDirection,
+  );
+};
+
+export const waitUntilAfterInitFade = true;

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetAnimationSpeedByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetAnimationSpeedByIndex.js
@@ -1,0 +1,38 @@
+export const id = "EVENT_ACTOR_SET_ANIMATION_SPEED_BY_INDEX";
+export const name = "Actor Set Animation Speed By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Set animation speed of actor ${fetchArg("actorIndex")} to ${fetchArg("speed")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the animation speed of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "speed",
+    label: "Animation Speed",
+    description: "Animation frame tick speed.",
+    type: "animSpeed",
+    defaultValue: 15,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorSetAnimationSpeed, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorSetAnimationSpeed(input.speed);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetCollisionBoxByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetCollisionBoxByIndex.js
@@ -1,0 +1,94 @@
+export const id = "EVENT_ACTOR_SET_COLLISION_BOX_BY_INDEX";
+export const name = "Actor Set Collision Box By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Set collision box of actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the collision box of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    fields: [
+      {
+        key: "x",
+        label: "X",
+        description: "Collision box X offset in pixels.",
+        type: "value",
+        min: -96,
+        max: 96,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "pixels",
+        unitsAllowed: ["pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+      {
+        key: "y",
+        label: "Y",
+        description: "Collision box Y offset in pixels.",
+        type: "value",
+        min: -96,
+        max: 96,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "pixels",
+        unitsAllowed: ["pixels"],
+        defaultValue: { type: "number", value: -8 },
+      },
+    ],
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    fields: [
+      {
+        key: "width",
+        label: "Width",
+        description: "Collision box width in pixels.",
+        type: "value",
+        min: 0,
+        max: 128,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "pixels",
+        unitsAllowed: ["pixels"],
+        defaultValue: { type: "number", value: 16 },
+      },
+      {
+        key: "height",
+        label: "Height",
+        description: "Collision box height in pixels.",
+        type: "value",
+        min: 0,
+        max: 128,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "pixels",
+        unitsAllowed: ["pixels"],
+        defaultValue: { type: "number", value: 16 },
+      },
+    ],
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetBoundToScriptValues, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetBoundToScriptValues(actorRef, input.x, input.y, input.width, input.height);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetDirectionByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetDirectionByIndex.js
@@ -1,0 +1,40 @@
+export const id = "EVENT_ACTOR_SET_DIRECTION_BY_INDEX";
+export const name = "Actor Set Direction By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Set direction of actor ${fetchArg("actorIndex")} to ${fetchArg("direction")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the direction of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "direction",
+    label: "Direction",
+    description: "Direction to face.",
+    type: "value",
+    defaultValue: {
+      type: "direction",
+      value: "up",
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetDirectionToScriptValue, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetDirectionToScriptValue(actorRef, input.direction);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetFrameByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetFrameByIndex.js
@@ -1,0 +1,38 @@
+export const id = "EVENT_ACTOR_SET_FRAME_BY_INDEX";
+export const name = "Actor Set Animation Frame By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Set animation frame of actor ${fetchArg("actorIndex")} to ${fetchArg("frame")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the animation frame of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "frame",
+    label: "Animation Frame",
+    description: "Animation frame to set.",
+    type: "value",
+    min: 0,
+    defaultValue: { type: "number", value: 0 },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetFrameToScriptValue, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetFrameToScriptValue(actorRef, input.frame);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetMovementSpeedByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetMovementSpeedByIndex.js
@@ -1,0 +1,38 @@
+export const id = "EVENT_ACTOR_SET_MOVEMENT_SPEED_BY_INDEX";
+export const name = "Actor Set Movement Speed By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Set movement speed of actor ${fetchArg("actorIndex")} to ${fetchArg("speed")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the movement speed of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "speed",
+    label: "Speed",
+    description: "Movement speed.",
+    type: "moveSpeed",
+    defaultValue: 1,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorSetMovementSpeed, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorSetMovementSpeed(input.speed);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetPositionByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetPositionByIndex.js
@@ -1,0 +1,63 @@
+export const id = "EVENT_ACTOR_SET_POSITION_BY_INDEX";
+export const name = "Actor Set Position By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_MOVEMENT",
+};
+
+export const autoLabel = (fetchArg, input) => {
+  const unitPostfix = input.units === "pixels" ? "px" : "";
+  return `Set position of actor ${fetchArg("actorIndex")} to ${fetchArg("x")}${unitPostfix}, ${fetchArg("y")}${unitPostfix}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the position of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    fields: [
+      {
+        key: "x",
+        label: "X",
+        description: "X position.",
+        type: "value",
+        min: 0,
+        max: 255,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+      {
+        key: "y",
+        label: "Y",
+        description: "Y position.",
+        type: "value",
+        min: 0,
+        max: 255,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+    ],
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetPositionToScriptValues, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetPositionToScriptValues(actorRef, input.x, input.y, input.units);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetPositionRelativeByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetPositionRelativeByIndex.js
@@ -1,0 +1,63 @@
+export const id = "EVENT_ACTOR_SET_POSITION_RELATIVE_BY_INDEX";
+export const name = "Actor Set Position Relative By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_MOVEMENT",
+};
+
+export const autoLabel = (fetchArg, input) => {
+  const unitPostfix = input.units === "pixels" ? "px" : "";
+  return `Set position of actor ${fetchArg("actorIndex")} relative by ${fetchArg("x")}${unitPostfix}, ${fetchArg("y")}${unitPostfix}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the relative position of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    fields: [
+      {
+        key: "x",
+        label: "X",
+        description: "Relative X offset.",
+        type: "value",
+        min: -31,
+        max: 31,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+      {
+        key: "y",
+        label: "Y",
+        description: "Relative Y offset.",
+        type: "value",
+        min: -31,
+        max: 31,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+    ],
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetPositionRelativeByScriptValues, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetPositionRelativeByScriptValues(actorRef, input.x, input.y, input.units);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetSpriteByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetSpriteByIndex.js
@@ -1,0 +1,38 @@
+export const id = "EVENT_ACTOR_SET_SPRITE_BY_INDEX";
+export const name = "Actor Set Sprite By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Set sprite of actor ${fetchArg("actorIndex")} to ${fetchArg("spriteSheetId")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the sprite of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "spriteSheetId",
+    label: "Sprite Sheet",
+    description: "Sprite sheet to assign to the actor.",
+    type: "sprite",
+    defaultValue: "LAST_SPRITE",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorSetSprite, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorSetSprite(input.spriteSheetId);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetStateByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorSetStateByIndex.js
@@ -1,0 +1,47 @@
+export const id = "EVENT_ACTOR_SET_STATE_BY_INDEX";
+export const name = "Actor Set Animation State By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_PROPERTIES",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Set animation state of actor ${fetchArg("actorIndex")} to ${fetchArg("spriteStateId") || "Default"}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the animation state of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "spriteStateId",
+    label: "Animation State",
+    description: "Animation state to set.",
+    type: "animationstate",
+    defaultValue: "",
+    width: "50%",
+  },
+  {
+    key: "loopAnim",
+    label: "Loop Animation",
+    description: "Whether to loop the animation.",
+    type: "checkbox",
+    defaultValue: true,
+    width: "50%",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorSetState, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorSetState(input.spriteStateId, input.loopAnim);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorShowByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorShowByIndex.js
@@ -1,0 +1,30 @@
+export const id = "EVENT_ACTOR_SHOW_BY_INDEX";
+export const name = "Actor Show By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_VISIBILITY",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Show actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to show.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorShow, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorShow(actorRef);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorStartUpdateByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorStartUpdateByIndex.js
@@ -1,0 +1,31 @@
+export const id = "EVENT_ACTOR_START_UPDATE_BY_INDEX";
+export const name = "Actor Start Update Script By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_SCRIPT",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Start update script for actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to start the update script for.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorStartUpdate, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorStartUpdate();
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventActorStopUpdateByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventActorStopUpdateByIndex.js
@@ -1,0 +1,31 @@
+export const id = "EVENT_ACTOR_STOP_UPDATE_BY_INDEX";
+export const name = "Actor Stop Update Script By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_SCRIPT",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `Stop update script for actor ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to stop the update script for.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, actorStopUpdate, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+  actorStopUpdate();
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventIfActorAtPositionByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventIfActorAtPositionByIndex.js
@@ -1,0 +1,100 @@
+export const id = "EVENT_IF_ACTOR_AT_POSITION_BY_INDEX";
+export const name = "If Actor At Position By Index";
+export const groups = ["EVENT_GROUP_CONTROL_FLOW", "EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_CONTROL_FLOW",
+  EVENT_GROUP_CONTROL_FLOW: "EVENT_GROUP_ACTOR",
+};
+
+export const autoLabel = (fetchArg, input) => {
+  const unitPostfix = input.units === "pixels" ? "px" : "";
+  return `If actor ${fetchArg("actorIndex")} at ${fetchArg("x")}${unitPostfix}, ${fetchArg("y")}${unitPostfix}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to check the position of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    fields: [
+      {
+        key: "x",
+        label: "X",
+        description: "X position to check.",
+        type: "value",
+        min: 0,
+        max: 255,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+      {
+        key: "y",
+        label: "Y",
+        description: "Y position to check.",
+        type: "value",
+        min: 0,
+        max: 255,
+        width: "50%",
+        unitsField: "units",
+        unitsDefault: "tiles",
+        unitsAllowed: ["tiles", "pixels"],
+        defaultValue: { type: "number", value: 0 },
+      },
+    ],
+  },
+  {
+    key: "true",
+    label: "True",
+    description: "Events to run if the condition is true.",
+    type: "events",
+  },
+  {
+    key: "__collapseElse",
+    label: "Else",
+    type: "collapsable",
+    defaultValue: true,
+    conditions: [
+      {
+        key: "__disableElse",
+        ne: true,
+      },
+    ],
+  },
+  {
+    key: "false",
+    label: "False",
+    description: "Events to run if the condition is false.",
+    conditions: [
+      {
+        key: "__collapseElse",
+        ne: true,
+      },
+      {
+        key: "__disableElse",
+        ne: true,
+      },
+    ],
+    type: "events",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { ifActorAtPositionByScriptValues, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  const truePath = input.true;
+  const falsePath = input.__disableElse ? [] : input.false;
+  ifActorAtPositionByScriptValues(actorRef, input.x, input.y, truePath, falsePath, input.units);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventIfActorDirectionByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventIfActorDirectionByIndex.js
@@ -1,0 +1,77 @@
+export const id = "EVENT_IF_ACTOR_DIRECTION_BY_INDEX";
+export const name = "If Actor Direction By Index";
+export const groups = ["EVENT_GROUP_CONTROL_FLOW", "EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_CONTROL_FLOW",
+  EVENT_GROUP_CONTROL_FLOW: "EVENT_GROUP_ACTOR",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `If actor ${fetchArg("actorIndex")} facing ${fetchArg("direction")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to check the direction of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "direction",
+    label: "Direction",
+    description: "Direction to check.",
+    type: "value",
+    defaultValue: {
+      type: "direction",
+      value: "up",
+    },
+  },
+  {
+    key: "true",
+    label: "True",
+    description: "Events to run if the condition is true.",
+    type: "events",
+  },
+  {
+    key: "__collapseElse",
+    label: "Else",
+    type: "collapsable",
+    defaultValue: true,
+    conditions: [
+      {
+        key: "__disableElse",
+        ne: true,
+      },
+    ],
+  },
+  {
+    key: "false",
+    label: "False",
+    description: "Events to run if the condition is false.",
+    conditions: [
+      {
+        key: "__collapseElse",
+        ne: true,
+      },
+      {
+        key: "__disableElse",
+        ne: true,
+      },
+    ],
+    type: "events",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { ifActorDirectionScriptValue, _declareLocal, variableSetToScriptValue } = helpers;
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  const truePath = input.true;
+  const falsePath = input.__disableElse ? [] : input.false;
+  ifActorDirectionScriptValue(actorRef, input.direction, truePath, falsePath);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventIfActorDistanceFromActorByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventIfActorDistanceFromActorByIndex.js
@@ -1,0 +1,119 @@
+export const id = "EVENT_IF_ACTOR_DISTANCE_FROM_ACTOR_BY_INDEX";
+export const name = "If Actor Distance From Actor By Index";
+export const groups = ["EVENT_GROUP_CONTROL_FLOW", "EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_CONTROL_FLOW",
+  EVENT_GROUP_CONTROL_FLOW: "EVENT_GROUP_ACTOR",
+};
+
+export const autoLabel = (fetchArg) => {
+  return `If actor ${fetchArg("actorIndex")} ${fetchArg("operator")} ${fetchArg("distance")} tiles from actor ${fetchArg("otherActorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the first actor.",
+    type: "value",
+    defaultValue: { type: "number", value: 0 },
+    width: "50%",
+  },
+  {
+    type: "group",
+    fields: [
+      {
+        key: "operator",
+        label: "Comparison",
+        description: "Distance comparison operator.",
+        type: "operator",
+        width: "50%",
+        defaultValue: "<=",
+      },
+      {
+        key: "distance",
+        label: "Distance",
+        description: "Distance in tiles.",
+        type: "value",
+        min: 0,
+        max: 181,
+        width: "50%",
+        unitsDefault: "tiles",
+        defaultValue: { type: "number", value: 0 },
+      },
+    ],
+  },
+  {
+    key: "otherActorIndex",
+    label: "Other Actor Index",
+    description: "Index of the second actor.",
+    type: "value",
+    defaultValue: { type: "number", value: 1 },
+    width: "50%",
+  },
+  {
+    key: "true",
+    label: "True",
+    description: "Events to run if the condition is true.",
+    type: "events",
+  },
+  {
+    key: "__collapseElse",
+    label: "Else",
+    type: "collapsable",
+    defaultValue: true,
+    conditions: [
+      {
+        key: "__disableElse",
+        ne: true,
+      },
+    ],
+  },
+  {
+    key: "false",
+    label: "False",
+    description: "Events to run if the condition is false.",
+    conditions: [
+      {
+        key: "__collapseElse",
+        ne: true,
+      },
+      {
+        key: "__disableElse",
+        ne: true,
+      },
+    ],
+    type: "events",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { ifActorDistanceScriptValueFromActor, _declareLocal, variableSetToScriptValue } = helpers;
+
+  const actorRef = _declareLocal("act_idx", 1, true);
+  const otherActorRef = _declareLocal("other_act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  variableSetToScriptValue(otherActorRef, input.otherActorIndex);
+
+  const operationLookup = {
+    "==": ".EQ",
+    "!=": ".NE",
+    "<": ".LT",
+    ">": ".GT",
+    "<=": ".LTE",
+    ">=": ".GTE",
+  };
+  const operator = operationLookup[input.operator];
+
+  const truePath = input.true;
+  const falsePath = input.__disableElse ? [] : input.false;
+
+  ifActorDistanceScriptValueFromActor(
+    actorRef,
+    input.distance,
+    operator,
+    otherActorRef,
+    truePath,
+    falsePath,
+  );
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventIfActorRelativeToActorByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventIfActorRelativeToActorByIndex.js
@@ -1,0 +1,93 @@
+export const id = "EVENT_IF_ACTOR_RELATIVE_TO_ACTOR_BY_INDEX";
+export const name = "If Actor Relative To Actor By Index";
+export const groups = ["EVENT_GROUP_CONTROL_FLOW", "EVENT_GROUP_ACTOR"];
+export const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_CONTROL_FLOW",
+  EVENT_GROUP_CONTROL_FLOW: "EVENT_GROUP_ACTOR",
+};
+
+export const autoLabel = (fetchArg) => {
+  const dir = fetchArg("operation");
+  const dirLabel = dir === "down" ? "below" : dir === "left" ? "left of" : dir === "right" ? "right of" : "above";
+  return `If actor ${fetchArg("actorIndex")} is ${dirLabel} actor ${fetchArg("otherActorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the first actor.",
+    type: "value",
+    defaultValue: { type: "number", value: 0 },
+  },
+  {
+    key: "operation",
+    label: "Comparison",
+    description: "Relative position comparison.",
+    type: "select",
+    options: [
+      ["up", "Is Above"],
+      ["down", "Is Below"],
+      ["left", "Is Left Of"],
+      ["right", "Is Right Of"],
+    ],
+    defaultValue: "up",
+    width: "50%",
+  },
+  {
+    key: "otherActorIndex",
+    label: "Other Actor Index",
+    description: "Index of the second actor.",
+    type: "value",
+    defaultValue: { type: "number", value: 1 },
+  },
+  {
+    key: "true",
+    label: "True",
+    description: "Events to run if the condition is true.",
+    type: "events",
+  },
+  {
+    key: "__collapseElse",
+    label: "Else",
+    type: "collapsable",
+    defaultValue: true,
+    conditions: [
+      {
+        key: "__disableElse",
+        ne: true,
+      },
+    ],
+  },
+  {
+    key: "false",
+    label: "False",
+    description: "Events to run if the condition is false.",
+    conditions: [
+      {
+        key: "__collapseElse",
+        ne: true,
+      },
+      {
+        key: "__disableElse",
+        ne: true,
+      },
+    ],
+    type: "events",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const { actorSetActive, ifActorRelativeToActor, _declareLocal, variableSetToScriptValue } = helpers;
+
+  const actorRef = _declareLocal("act_idx", 1, true);
+  const otherActorRef = _declareLocal("other_act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  variableSetToScriptValue(otherActorRef, input.otherActorIndex);
+
+  const truePath = input.true;
+  const falsePath = input.__disableElse ? [] : input.false;
+
+  actorSetActive(actorRef);
+  ifActorRelativeToActor(input.operation, otherActorRef, truePath, falsePath);
+};

--- a/plugins/Mico27/ActorByIndexPlugin/events/eventLaunchProjectileSlotByIndex.js
+++ b/plugins/Mico27/ActorByIndexPlugin/events/eventLaunchProjectileSlotByIndex.js
@@ -1,0 +1,216 @@
+const l10n = require("../helpers/l10n").default;
+
+const id = "EVENT_LAUNCH_PROJECTILE_SLOT_BY_INDEX";
+const name = "Launch Projectile Slot By Index";
+const groups = ["EVENT_GROUP_ACTOR"];
+const subGroups = {
+  EVENT_GROUP_ACTOR: "EVENT_GROUP_ACTIONS",
+};
+
+const fields = [
+  {
+    key: "__section",
+    type: "tabs",
+    defaultValue: "source",
+    variant: "eventSection",
+    values: {
+      source: l10n("FIELD_SOURCE"),
+      presets: l10n("FIELD_PRESETS"),
+    },
+  },
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the source actor that launches the projectile.",
+    type: "value",
+    defaultValue: { type: "number", value: 0 },
+    conditions: [{ key: "__section", in: ["source", undefined] }],
+  },
+  {
+    type: "group",
+    conditions: [{ key: "__section", in: ["source", undefined] }],
+    fields: [
+      {
+        key: "x",
+        label: l10n("FIELD_OFFSET_X"),
+        description: l10n("FIELD_PROJECTILE_OFFSET_X_DESC"),
+        type: "number",
+        min: -256,
+        max: 256,
+        width: "50%",
+        defaultValue: 0,
+      },
+      {
+        key: "y",
+        label: l10n("FIELD_OFFSET_Y"),
+        description: l10n("FIELD_PROJECTILE_OFFSET_Y_DESC"),
+        type: "number",
+        min: -256,
+        max: 256,
+        width: "50%",
+        defaultValue: 0,
+      },
+    ],
+  },
+  {
+    type: "group",
+    conditions: [{ key: "__section", in: ["source", undefined] }],
+    fields: [
+      {
+        label: l10n("FIELD_LAUNCH_AT"),
+        key: "directionType",
+        type: "select",
+        options: [
+          ["direction", l10n("FIELD_FIXED_DIRECTION")],
+          ["actor", l10n("FIELD_ACTOR_DIRECTION")],
+          ["target", l10n("FIELD_ACTOR_TARGET")],
+          ["angle", l10n("FIELD_ANGLE")],
+          ["anglevar", l10n("FIELD_ANGLE_VARIABLE")],
+        ],
+        defaultValue: "direction",
+        alignBottom: true,
+      },
+      {
+        key: "otherActorIndex",
+        label: "Direction Actor Index",
+        description: l10n("FIELD_PROJECTILE_DIRECTION_DESC"),
+        type: "value",
+        defaultValue: { type: "number", value: 0 },
+        conditions: [{ key: "directionType", eq: "actor" }],
+      },
+      {
+        key: "direction",
+        label: l10n("FIELD_DIRECTION"),
+        description: l10n("FIELD_PROJECTILE_DIRECTION_DESC"),
+        type: "direction",
+        defaultValue: "right",
+        conditions: [{ key: "directionType", eq: "direction" }],
+      },
+      {
+        key: "angle",
+        label: l10n("FIELD_ANGLE"),
+        description: l10n("FIELD_PROJECTILE_ANGLE_DESC"),
+        type: "angle",
+        defaultValue: 0,
+        min: -256,
+        max: 256,
+        conditions: [{ key: "directionType", eq: "angle" }],
+      },
+      {
+        key: "angleVariable",
+        label: l10n("FIELD_ANGLE"),
+        description: l10n("FIELD_PROJECTILE_ANGLE_DESC"),
+        type: "variable",
+        defaultValue: "LAST_VARIABLE",
+        conditions: [{ key: "directionType", eq: "anglevar" }],
+      },
+      {
+        key: "targetActorIndex",
+        label: "Target Actor Index",
+        description: l10n("FIELD_PROJECTILE_TARGET_DESC"),
+        type: "value",
+        defaultValue: { type: "number", value: 0 },
+        conditions: [{ key: "directionType", eq: "target" }],
+      },
+    ],
+  },
+  {
+    key: "slot",
+    label: l10n("FIELD_PROJECTILE_SLOT"),
+    description: l10n("FIELD_PROJECTILE_SLOT_DESC"),
+    type: "togglebuttons",
+    options: [0, 1, 2, 3, 4].map((n) => [
+      n,
+      l10n("FIELD_SLOT_N", { slot: n + 1 }),
+      l10n("FIELD_PROJECTILE_SLOT_N", { slot: n + 1 }),
+    ]),
+    allowNone: false,
+    defaultValue: 0,
+    conditions: [{ key: "__section", in: ["source", undefined] }],
+  },
+  {
+    type: "presets",
+    conditions: [{ key: "__section", in: ["presets"] }],
+  },
+];
+
+const userPresetsGroups = [
+  {
+    id: "slot",
+    label: l10n("FIELD_PROJECTILE_SLOT"),
+    fields: ["slot"],
+    selected: true,
+  },
+  {
+    id: "source",
+    label: l10n("FIELD_SOURCE"),
+    fields: ["actorIndex", "x", "y"],
+    selected: true,
+  },
+  {
+    id: "direction",
+    label: l10n("FIELD_DIRECTION"),
+    fields: [
+      "directionType",
+      "otherActorIndex",
+      "direction",
+      "angle",
+      "angleVariable",
+      "targetActorIndex",
+    ],
+    selected: true,
+  },
+];
+
+const userPresetsIgnore = ["__section"];
+
+const compile = (input, helpers) => {
+  const {
+    launchProjectileInDirection,
+    launchProjectileInAngle,
+    launchProjectileInActorDirection,
+    launchProjectileInAngleVariable,
+    launchProjectileTowardsActor,
+    actorSetActive,
+    _declareLocal,
+    variableSetToScriptValue,
+  } = helpers;
+
+  const actorRef = _declareLocal("act_idx", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  actorSetActive(actorRef);
+
+  const projectileIndex = input.slot;
+  if (projectileIndex < 0) {
+    return;
+  }
+
+  if (input.directionType === "direction") {
+    launchProjectileInDirection(projectileIndex, input.x, input.y, input.direction);
+  } else if (input.directionType === "angle") {
+    launchProjectileInAngle(projectileIndex, input.x, input.y, input.angle);
+  } else if (input.directionType === "anglevar") {
+    launchProjectileInAngleVariable(projectileIndex, input.x, input.y, input.angleVariable);
+  } else if (input.directionType === "actor") {
+    const otherActorRef = _declareLocal("other_act_idx", 1, true);
+    variableSetToScriptValue(otherActorRef, input.otherActorIndex);
+    launchProjectileInActorDirection(projectileIndex, input.x, input.y, otherActorRef);
+  } else if (input.directionType === "target") {
+    const targetActorRef = _declareLocal("target_act_idx", 1, true);
+    variableSetToScriptValue(targetActorRef, input.targetActorIndex);
+    launchProjectileTowardsActor(projectileIndex, input.x, input.y, targetActorRef);
+  }
+};
+
+module.exports = {
+  id,
+  name,
+  description: "Launch a pre-loaded projectile slot from the actor at a given index.",
+  groups,
+  subGroups,
+  fields,
+  compile,
+  userPresetsGroups,
+  userPresetsIgnore,
+  waitUntilAfterInitFade: true,
+};

--- a/plugins/Mico27/ActorByIndexPlugin/plugin.json
+++ b/plugins/Mico27/ActorByIndexPlugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "type": "eventsPlugin",
+  "name": "Actor By Index",
+  "author": "Mico27",
+  "url": "https://github.com/Mico27/gbs-ActorByIndexPlugin",
+  "description": "This plugin creates a version of all the actor related events allowing an actor index to be passed.",
+  "license": "MIT",
+  "version": "4.3.0",
+  "gbsVersion": ">=4.3.0"
+}


### PR DESCRIPTION
New plugin that creates a version of all the existing actor related event to allow passing in an actor index.
The plugin also adds a "Actor Get Index To Variable" event to store an actor index into a variable.
This plugins makes it so you can do dynamic actor targetting and also resolve a common problem with custom script where you cannot refer to actor passed in parameters inside an attach script because the actor reference is saved on stack and therefore no longer accessible when the attach script executes due to difference in context.
More details here: https://github.com/Mico27/gbs-ActorByIndexPlugin