### PR TITLE
Various fixes to the DynamicActorPlugin and compability fix for metatile plugin

### DIFF
--- a/plugins/Mico27/DynamicActorPlugin/engine/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engine/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engine/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engine/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engine/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engine/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engine/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engine/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engine/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engine/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engine/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engine/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engine/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engine/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_M_Sce/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_Sce/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_M_Sce/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Cont_ScreenS_Sce/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/M_Sce/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/Sce/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_M_Sce/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/engine.json
@@ -11,6 +11,15 @@
           "defaultValue": 1
         },
         {
+          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
+          "label": "Collision model: Triangle",
+          "description": "Compile the triangle collision model.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/engine.json
@@ -51,7 +51,7 @@
         {
           "key": "DYNAMIC_ACTOR_MAX_PLATFORMS",
           "label": "Max moving platforms",
-          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 12 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
+          "description": "Number of 'Moving platform' actors that can claim/release riders per scene (each uses 11 bytes of RAM). Platforms beyond this limit still move but never pick up riders. Requires the parent actors component.",
           "group": "Dynamic actor",
           "type": "slider",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/engine.json
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/engine.json
@@ -11,15 +11,6 @@
           "defaultValue": 1
         },
         {
-          "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE",
-          "label": "Collision model: Triangle",
-          "description": "Compile the triangle collision model.",
-          "group": "Dynamic actor",
-          "type": "checkbox",
-          "cType": "define",
-          "defaultValue": 1
-        },
-        {
           "key": "DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX",
           "label": "Collision model: Bounding box",
           "description": "Compile the bounding-box collision model.",
@@ -206,6 +197,24 @@
           "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION",
           "label": "VM: Wait for collision",
           "description": "Compile vm_wait_for_collision waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE",
+          "label": "VM: Wait for actor in range",
+          "description": "Compile vm_wait_for_actor_in_range waitable helper.",
+          "group": "Dynamic actor",
+          "type": "checkbox",
+          "cType": "define",
+          "defaultValue": 1
+        },
+        {
+          "key": "DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE",
+          "label": "VM: Wait for actor state",
+          "description": "Compile vm_wait_for_actor_state waitable helper.",
           "group": "Dynamic actor",
           "type": "checkbox",
           "cType": "define",

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/src/dynamic_actor.c
@@ -17,7 +17,6 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
-#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -359,7 +358,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -403,116 +402,6 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
-
-#endif
-
-
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
-static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
-    if (down) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
-        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
-        if (slope_y != start_y) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-        }
-        return slope_y;
-#else
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
-        }
-        return start_y;
-#endif
-    }
-    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
-    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
-        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
-    }
-    return start_y;
-}
-#endif
-
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
-static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    return start_x;
-}
-#endif
-
-#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
-static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
-    if (right) {
-        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
-        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
-                return start_x;
-            }
-#endif
-            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
-        }
-        return start_x;
-    }
-    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
-    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
-    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
-#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
-            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
-                return start_x;
-            }
-#endif
-        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
-        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
-    }
-    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
-        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
-        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
-    }
-    return start_x;
-}
-#endif
 
 #endif
 
@@ -624,10 +513,6 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -646,10 +531,6 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -667,10 +548,6 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
-            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
-#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -688,8 +565,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point / triangle platforms still pick up
-// riders standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point platforms still pick up riders
+// standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/src/dynamic_actor.c
@@ -17,6 +17,7 @@
 #endif
 
 #define DYNAMIC_ACTOR_COLLISION_SINGLE_POINT 0
+#define DYNAMIC_ACTOR_COLLISION_TRIANGLE 1
 #define DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX 2
 
 #define COLLISION_SLOPE_LEFT          0x10u
@@ -358,7 +359,7 @@ static UWORD check_pit_point(UWORD start_x, UWORD start_y, UBYTE right) {
 
 #endif
 
-#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX)
+#if defined(DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION) && defined(DYNAMIC_ACTOR_ENABLE_MOVE_Y) && (defined(DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE) || defined(DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX))
 static UBYTE on_slope;
 static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bounds){
     col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
@@ -402,6 +403,116 @@ static UWORD check_collision_slope(UWORD start_x, UWORD start_y, rect16_t *bound
     }
     return start_y;
 }
+
+#endif
+
+
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+static UWORD check_vertical_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE down) {
+    if (down) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+        UWORD middle_pos = start_x + bounds->left + ((bounds->right - bounds->left) >> 1);
+        UWORD slope_y = check_collision_slope(middle_pos, start_y, bounds);
+        if (slope_y != start_y) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+        }
+        return slope_y;
+#else
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        if (tile_at(col_tx, col_ty) & COLLISION_TOP) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_ty) - (bounds->bottom + 1);
+        }
+        return start_y;
+#endif
+    }
+    col_ty = SUBPX_TO_TILE(start_y + bounds->top);
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left + ((bounds->right - bounds->left) >> 1));
+    if (tile_at(col_tx, col_ty) & COLLISION_BOTTOM) {
+        dynamic_actor_execute_tile_collision_top(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_ty + 1) - bounds->top;
+    }
+    return start_y;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+static UWORD check_horizontal_collision_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    return start_x;
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_MOVE_X) && defined(DYNAMIC_ACTOR_ENABLE_LEDGE_STOP)
+static UWORD check_pit_triangle(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYTE right) {
+    if (right) {
+        col_tx = SUBPX_TO_TILE(start_x + bounds->right);
+        col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+        if (tile_at(col_tx, col_ty) & COLLISION_LEFT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx - 1, col_ty))){
+                return start_x;
+            }
+#endif
+            dynamic_actor_execute_tile_collision_right(dynamic_actor_current_actor, col_tx, col_ty);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+            dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+            return TILE_TO_SUBPX(col_tx) - (bounds->right + 1);
+        }
+        return start_x;
+    }
+    col_tx = SUBPX_TO_TILE(start_x + bounds->left);
+    col_ty = SUBPX_TO_TILE(start_y + bounds->bottom);
+    if (tile_at(col_tx, col_ty) & COLLISION_RIGHT) {
+#ifdef DYNAMIC_ACTOR_ENABLE_SLOPE_COLLISION
+            if (IS_ON_SLOPE(tile_at(col_tx + 1, col_ty))){
+                return start_x;
+            }
+#endif
+        dynamic_actor_execute_tile_collision_left(dynamic_actor_current_actor, col_tx, col_ty);
+        return TILE_TO_SUBPX(col_tx + 1) - bounds->left;
+    }
+    if (!(tile_at(col_tx, col_ty + 1) & (COLLISION_TOP | COLLISION_SLOPE_ANY))) {
+        dynamic_actor_execute_tile_collision_bottom(dynamic_actor_current_actor, col_tx, col_ty + 1);
+        return TILE_TO_SUBPX(col_tx + 1)  - bounds->left;
+    }
+    return start_x;
+}
+#endif
 
 #endif
 
@@ -513,6 +624,10 @@ static UWORD check_pit_bbox(UWORD start_x, UWORD start_y, rect16_t *bounds, UBYT
 static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_horizontal_collision_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_horizontal_collision_bbox(start_x, start_y, &actor->bounds, right);
@@ -531,6 +646,10 @@ static UWORD check_horizontal_collision_by_type(UWORD start_x, UWORD start_y, ac
 static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE down, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_vertical_collision_triangle(start_x, start_y, &actor->bounds, down);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_vertical_collision_bbox(start_x, start_y, &actor->bounds, down);
@@ -548,6 +667,10 @@ static UWORD check_vertical_collision_by_type(UWORD start_x, UWORD start_y, acto
 static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBYTE right, UBYTE collision_type) {
     (void)actor;
     switch (collision_type) {
+#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
+        case DYNAMIC_ACTOR_COLLISION_TRIANGLE:
+            return check_pit_triangle(start_x, start_y, &actor->bounds, right);
+#endif
 #ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
         case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
             return check_pit_bbox(start_x, start_y, &actor->bounds, right);
@@ -565,8 +688,8 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 // Claim/release intersection test between a cached platform box and a candidate
 // rider: a plain bounding-box overlap (they touch). This is deliberately
 // independent of either actor's tile-collision model - a moving platform parents
-// whatever its box overlaps, so single-point platforms still pick up riders
-// standing on them (their origin/point need not be inside the box).
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
     return ((other->pos.x + other->bounds.left) <= p->right) &&
            ((other->pos.x + other->bounds.right) >= p->left) &&

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/src/dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/src/dynamic_actor.c
@@ -68,7 +68,6 @@ typedef struct platform_cache_t {
     UWORD right;
     UWORD top;
     UWORD bottom;
-    UBYTE collision_type;
     UBYTE group;
 } platform_cache_t;
 static platform_cache_t platform_cache[DYNAMIC_ACTOR_MAX_PLATFORMS];
@@ -686,33 +685,85 @@ static UWORD check_pit_by_type(UWORD start_x, UWORD start_y, actor_t *actor, UBY
 #endif
 
 #ifdef DYNAMIC_ACTOR_ENABLE_PARENT
-// Claim/release intersection test between a cached platform box and a
-// candidate rider. The candidate's shape follows the platform's collision
-// model: bottom-center point (triangle), full box (bounding box) or origin
-// point (single point). The platform side is always its precomputed box.
+// Claim/release intersection test between a cached platform box and a candidate
+// rider: a plain bounding-box overlap (they touch). This is deliberately
+// independent of either actor's tile-collision model - a moving platform parents
+// whatever its box overlaps, so single-point / triangle platforms still pick up
+// riders standing on them (their origin/point need not be inside the box).
 static UBYTE platform_cache_test(platform_cache_t *p, actor_t *other) {
-    switch (p->collision_type) {
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_TRIANGLE
-        case DYNAMIC_ACTOR_COLLISION_TRIANGLE: {
-            UWORD point_x = other->pos.x + other->bounds.left + ((other->bounds.right - other->bounds.left) >> 1);
-            UWORD point_y = other->pos.y + other->bounds.bottom;
-            return (point_x >= p->left) && (point_x <= p->right) && (point_y >= p->top) && (point_y <= p->bottom);
+    return ((other->pos.x + other->bounds.left) <= p->right) &&
+           ((other->pos.x + other->bounds.right) >= p->left) &&
+           ((other->pos.y + other->bounds.top) <= p->bottom) &&
+           ((other->pos.y + other->bounds.bottom) >= p->top);
+}
+#endif
+
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_DELTA)
+// Apply the summed position delta of an actor's whole parent chain since last
+// frame (tile-collision checked). Called from the end-of-frame pass, after every
+// actor has its final position but before any prev_pos is snapshotted - so every
+// parent still holds last frame's snapshot and the delta is identical regardless
+// of the order the actor and its parents happened to be processed in. (Doing this
+// in the main loop instead reads a 0 delta whenever the parent is processed after
+// the rider, which left riders stuck.)
+static void dynamic_actor_apply_parent_delta(actor_t *actor) {
+    behavior_def_t *def = &behavior_defs[actor->actor_behavior_id];
+    UBYTE flags = def->flags;
+    UBYTE flags2 = def->flags2;
+    UBYTE collision_type = def->collision_type;
+    WORD parent_actor_delta_x = 0;
+    WORD parent_actor_delta_y = 0;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    WORD parent_actor_delta_z = 0;
+#endif
+    actor_t *chain_actor = actor->actor_parent;
+    UBYTE chain_guard = MAX_ACTORS;
+    while (chain_actor && chain_guard) {
+        parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
+        parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+        parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
+#endif
+        chain_actor = chain_actor->actor_parent;
+        chain_guard--;
+    }
+    // Set the current actor so the collision helpers fire this rider's tile
+    // collision events (they read dynamic_actor_current_actor).
+    dynamic_actor_current_actor = actor;
+    if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
+        new_actor_x = actor->pos.x + parent_actor_delta_x;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.x = new_actor_x;
+        } else {
+            actor->pos.x = check_horizontal_collision_by_type(new_actor_x, actor->pos.y, actor, (parent_actor_delta_x > 0), collision_type);
         }
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_BOUNDING_BOX
-        case DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX:
-            return ((other->pos.x + other->bounds.left) <= p->right) &&
-                   ((other->pos.x + other->bounds.right) >= p->left) &&
-                   ((other->pos.y + other->bounds.top) <= p->bottom) &&
-                   ((other->pos.y + other->bounds.bottom) >= p->top);
-#endif
-#ifdef DYNAMIC_ACTOR_ENABLE_COLLISION_SINGLE_POINT
-        case DYNAMIC_ACTOR_COLLISION_SINGLE_POINT:
-            return (other->pos.x >= p->left) && (other->pos.x <= p->right) &&
-                   (other->pos.y >= p->top) && (other->pos.y <= p->bottom);
+#else
+        actor->pos.x = new_actor_x;
 #endif
     }
-    return FALSE;
+    if (parent_actor_delta_y && !(flags2 & BHV3_LOCK_POS_Y)) {
+        new_actor_y = actor->pos.y + parent_actor_delta_y;
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Y
+        if (CHK_FLAG(flags, BHV2_NO_TILE_COLLISION)) {
+            actor->pos.y = new_actor_y;
+        } else {
+            actor->pos.y = check_vertical_collision_by_type(actor->pos.x, new_actor_y, actor, (parent_actor_delta_y > 0), collision_type);
+        }
+#else
+        actor->pos.y = new_actor_y;
+#endif
+    }
+#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
+    if (parent_actor_delta_z && !(flags2 & BHV3_LOCK_POS_Z)) {
+        new_actor_z = (WORD)actor->pos_z + parent_actor_delta_z;
+        if (new_actor_z < 0) {
+            actor->pos_z = 0;
+        } else {
+            actor->pos_z = (UWORD)new_actor_z;
+        }
+    }
+#endif
 }
 #endif
 
@@ -751,7 +802,7 @@ void dynamic_actor_update(void) BANKED {
             start_tile_y = SUBPX_TO_TILE(actor->pos.y);
         }
 
-#ifdef DYNAMIC_ACTOR_ENABLE_PARENT
+#if defined(DYNAMIC_ACTOR_ENABLE_PARENT) && (DYNAMIC_ACTOR_PARENT_MODE != DYNAMIC_ACTOR_PARENT_MODE_DELTA)
         // Parenting is not a behavior: every actor with a defined parent
         // inherits the parent actor's per-frame movement (tile-collision
         // checked, like riding a moving platform), then still runs its own
@@ -759,6 +810,11 @@ void dynamic_actor_update(void) BANKED {
         // behavior assigned (slot 0 is zeroed, so tile collision stays on) or
         // a paused one. Set the parent explicitly with the Set Actor Parent
         // Actor events, or automatically via a BHV_PLATFORM actor.
+        // NOTE: the "apply all parents positions delta" mode does NOT carry here.
+        // It carries at the END of the frame (dynamic_actor_apply_parent_delta),
+        // after every actor has its final position, so a rider inherits the same
+        // delta no matter what order it and its parent were processed in - doing
+        // it here would read a 0 delta whenever the parent hadn't moved yet.
         if (actor->actor_parent) {
             actor_t *parent_actor = actor->actor_parent;
 
@@ -781,22 +837,16 @@ void dynamic_actor_update(void) BANKED {
             actor = actor->prev;
             continue;
 #else
-            // The displacement is tile-collision checked: a parented actor
-            // normally only checks collision when it moves itself, so
-            // without this the parent actor's movement could push this
-            // actor through walls. Disabled by the behavior's
-            // 'no tile collision' option.
-#if DYNAMIC_ACTOR_PARENT_MODE == DYNAMIC_ACTOR_PARENT_MODE_VELOCITY
             // Inherit first parent velocity (Slower): the actor is carried by
-            // its direct parent's current velocity, then runs its own behavior.
+            // its direct parent's current velocity (tile-collision checked),
+            // then runs its own behavior. The player has no velocity field
+            // (engine-moved), so track it by its position delta instead.
             WORD parent_actor_delta_x;
             WORD parent_actor_delta_y;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             WORD parent_actor_delta_z;
 #endif
             if (parent_actor == &PLAYER) {
-                // The engine-controlled player never populates a velocity field,
-                // so track it by its position delta since last frame instead.
                 parent_actor_delta_x = (WORD)(PLAYER.pos.x - player_prev_pos.x);
                 parent_actor_delta_y = (WORD)(PLAYER.pos.y - player_prev_pos.y);
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
@@ -809,32 +859,6 @@ void dynamic_actor_update(void) BANKED {
                 parent_actor_delta_z = (WORD)parent_actor->actor_vel_z;
 #endif
             }
-#else
-            // Apply all parents positions delta (Slowest): walk the whole
-            // parent chain and sum each ancestor's position delta since last
-            // frame, so a parented actor keeps up with a chain of movers in a
-            // single frame (no per-level lag) and follows engine-moved parents
-            // (like the player) that never populate a velocity field. Then run
-            // its own behavior physics.
-            WORD parent_actor_delta_x = 0;
-            WORD parent_actor_delta_y = 0;
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-            WORD parent_actor_delta_z = 0;
-#endif
-            {
-                actor_t *chain_actor = parent_actor;
-                UBYTE chain_guard = MAX_ACTORS;
-                while (chain_actor && chain_guard) {
-                    parent_actor_delta_x += (WORD)(chain_actor->pos.x - chain_actor->prev_pos.x);
-                    parent_actor_delta_y += (WORD)(chain_actor->pos.y - chain_actor->prev_pos.y);
-#ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
-                    parent_actor_delta_z += (WORD)(chain_actor->pos_z - chain_actor->prev_pos_z);
-#endif
-                    chain_actor = chain_actor->actor_parent;
-                    chain_guard--;
-                }
-            }
-#endif
             if (parent_actor_delta_x && !(flags2 & BHV3_LOCK_POS_X)) {
                 new_actor_x = actor->pos.x + parent_actor_delta_x;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_X
@@ -1150,7 +1174,6 @@ void dynamic_actor_update(void) BANKED {
             p->right = actor->pos.x + actor->bounds.right;
             p->top = actor->pos.y + actor->bounds.top;
             p->bottom = actor->pos.y + actor->bounds.bottom;
-            p->collision_type = collision_type;
             p->group = actor->collision_group & COLLISION_GROUP_MASK;
         }
 #endif
@@ -1167,6 +1190,15 @@ void dynamic_actor_update(void) BANKED {
     if (dynamic_actor_parenting_used) {
         actor = actors_active_tail;
         while (actor) {
+#ifdef DYNAMIC_ACTOR_USES_PREV_POS
+            // "Apply all parents positions delta" carry, done here (end of frame,
+            // before any prev_pos snapshot) so it is order-independent. Uses the
+            // parent set on a previous frame - a rider claimed by the block below
+            // this frame starts moving next frame.
+            if (actor->actor_parent) {
+                dynamic_actor_apply_parent_delta(actor);
+            }
+#endif
             if (actor->actor_parent == NULL
 #ifdef DYNAMIC_ACTOR_PLATFORM_PLAYER_ONLY
                 // Platforms only auto-attach the player; other actors are never
@@ -1174,15 +1206,17 @@ void dynamic_actor_update(void) BANKED {
                 && (actor == &PLAYER)
 #endif
             ) {
-                // Unparented: the first intersecting platform claims it,
-                // unless the platform has a collision group and this actor's
-                // group differs (a group-less platform claims everything,
-                // including the player).
+                // Unparented: the first intersecting platform claims it, unless
+                // the platform has a collision group and this actor's group
+                // differs (a group-less platform claims everything). The player
+                // is always eligible - a platform picks it up no matter its
+                // collision group.
                 platform_cache_t *p = platform_cache;
                 UBYTE i = platform_count;
                 while (i) {
                     if ((p->actor != actor) &&
-                        ((p->group == COLLISION_GROUP_NONE) ||
+                        ((actor == &PLAYER) ||
+                         (p->group == COLLISION_GROUP_NONE) ||
                          (p->group == (actor->collision_group & COLLISION_GROUP_MASK))) &&
                         platform_cache_test(p, actor)) {
                         actor->actor_parent = p->actor;
@@ -1208,14 +1242,20 @@ void dynamic_actor_update(void) BANKED {
                     i--;
                 }
             }
+            actor = actor->prev;
+        }
 #ifdef DYNAMIC_ACTOR_USES_PREV_POS
+        // Snapshot every actor's final position AFTER all carries above, in a
+        // separate pass, so the carry always reads last frame's snapshot.
+        actor = actors_active_tail;
+        while (actor) {
             actor->prev_pos = actor->pos;
 #ifdef DYNAMIC_ACTOR_ENABLE_MOVE_Z
             actor->prev_pos_z = actor->pos_z;
 #endif
-#endif
             actor = actor->prev;
         }
+#endif
 #ifdef DYNAMIC_ACTOR_USES_PLAYER_PREV_POS
         // Snapshot the player for next frame's player-parent position delta.
         player_prev_pos = PLAYER.pos;

--- a/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/src/vm_dynamic_actor.c
+++ b/plugins/Mico27/DynamicActorPlugin/engineAlt/ScreenS_Sce/src/vm_dynamic_actor.c
@@ -563,3 +563,79 @@ UBYTE vm_actor_move_to_pos_by_velocity(void * THIS, UBYTE start, UWORD * stack_f
     return FALSE;
 }
 #endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_IN_RANGE
+#define WAIT_RNG_X       0x01u  // include the x axis in the distance test
+#define WAIT_RNG_Y       0x02u  // include the y axis in the distance test
+#define WAIT_RNG_OUTSIDE 0x04u  // finish when the target is out of range instead
+
+// Wait until a target actor is inside (or outside) a rectangular range around
+// another actor. Both ranges are half-extents in the same subpixel units as
+// actor->pos, so the event multiplies its pixel fields by the subpixel scale.
+// An axis that is not selected is simply not tested; with no axis selected the
+// actor always counts as inside.
+// Stack frame: [0] actor index, [1] target actor index, [2] WAIT_RNG_* flags,
+//              [3] x range, [4] y range.
+UBYTE vm_wait_for_actor_in_range(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    actor_t * target = actors + (UBYTE)stack_frame[1];
+    UBYTE flags = (UBYTE)stack_frame[2];
+    UBYTE inside = TRUE;
+
+    if (flags & WAIT_RNG_X) {
+        UWORD a = actor->pos.x, b = target->pos.x;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[3]) {
+            inside = FALSE;
+        }
+    }
+    if (inside && (flags & WAIT_RNG_Y)) {
+        UWORD a = actor->pos.y, b = target->pos.y;
+        if (((a > b) ? (a - b) : (b - a)) > stack_frame[4]) {
+            inside = FALSE;
+        }
+    }
+
+    if (flags & WAIT_RNG_OUTSIDE) {
+        if (!inside) return TRUE;
+    } else if (inside) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif
+
+#ifdef DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_STATE
+// Wait until an actor's behavior state matches (or stops matching) a state.
+// Stack frame: [0] actor index, [1] BHV_STATE_* value, [2] nonzero to invert.
+UBYTE vm_wait_for_actor_state(void * THIS, UBYTE start, UWORD * stack_frame) OLDCALL BANKED {
+    actor_t * actor = actors + (UBYTE)stack_frame[0];
+    if (start) {
+        CLR_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT);
+    } else {
+        // Interrupt actor movement
+        if (CHK_FLAG(actor->flags, ACTOR_FLAG_INTERRUPT)) {
+            return TRUE;
+        }
+    }
+    UBYTE match = (actor->actor_state == (UBYTE)stack_frame[1]);
+    if (stack_frame[2]) {
+        match = !match;
+    }
+    if (match) {
+        return TRUE;
+    }
+
+    ((SCRIPT_CTX *)THIS)->waitable = TRUE;
+    return FALSE;
+}
+#endif

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorChaseActorByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorChaseActorByIndex.js
@@ -1,0 +1,111 @@
+export const id = "EVENT_ACTOR_CHASE_ACTOR_BY_INDEX";
+export const name = "Actor Chase Actor By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg, input) => {
+  const verb = input.mode === "flee" ? "flee from" : "chase";
+  return `Actor ${fetchArg("actorIndex")} ${verb} ${fetchArg("targetActorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to steer.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "targetActorIndex",
+    label: "Target actor index",
+    description: "Index of the actor to chase or flee from (0 = player).",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "mode",
+    label: "Mode",
+    description: "Steer toward the target (chase) or away from it (flee)",
+    type: "select",
+    options: [
+      ["chase", "Chase"],
+      ["flee", "Flee"],
+    ],
+    defaultValue: "chase",
+  },
+  {
+    key: "stopRange",
+    label: "Stop range",
+    description:
+      "Chase: stops once within this range of the target on every steered axis. Flee: stops once beyond this range on any steered axis. 0 = never stop (chase/flee forever - place in a looping thread or an actor's update script).",
+    type: "value",
+    min: 0,
+    max: 32767,
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "interval",
+    label: "Target refresh interval",
+    description:
+      "How often (in frames) to refresh the chased target position from the target actor. Must be a power of 2.",
+    type: "select",
+    options: [
+      ["0", "1 frame"],
+      ["1", "2 frames"],
+      ["3", "4 frames"],
+      ["7", "8 frames"],
+      ["15", "16 frames"],
+      ["31", "32 frames"],
+      ["63", "64 frames"],
+      ["127", "128 frames"],
+    ],
+    defaultValue: "0",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_VM_MOTION_CHASE_ACTOR", "VM motion: Chase actor");
+
+  const { variableSetToScriptValue, _invoke, _stackPush, _stackPushConst, _stackPushScriptValue, _addComment, _declareLocal } = helpers;
+
+  const actorRef = _declareLocal("actorRef", 1, true);
+  const targetRef = _declareLocal("targetRef", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  variableSetToScriptValue(targetRef, input.targetActorIndex);
+
+  _addComment("Actor Chase Actor By Index");
+
+  _stackPush(actorRef);
+  _stackPush(targetRef);
+  _stackPushConst(input.mode === "flee" ? 1 : 0);
+  _stackPushScriptValue(input.stopRange);
+  _stackPushConst(input.interval);
+  _stackPushConst(0);
+  _stackPushConst(0);
+  
+  _invoke("vm_actor_chase_actor", 7, ".ARG6");
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionBezierByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionBezierByIndex.js
@@ -1,0 +1,296 @@
+const l10n = require("../helpers/l10n").default;
+
+export const id = "EVENT_ACTOR_MOTION_BEZIER_BY_INDEX";
+export const name = "Actor Motion: Bezier By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg) => {
+  return `Bezier Motion : ${fetchArg("actorIndex")}`;
+};
+
+const lerp = (a, b, t) => a + (b - a) * t;
+
+const quadraticBezier = (p0, p1, p2, t) => {
+  const a = lerp(p0, p1, t);
+  const b = lerp(p1, p2, t);
+  return lerp(a, b, t);
+};
+
+const cubicBezier = (p0, p1, p2, p3, t) => {
+  const a = lerp(p0, p1, t);
+  const b = lerp(p1, p2, t);
+  const c = lerp(p2, p3, t);
+  const d = lerp(a, b, t);
+  const e = lerp(b, c, t);
+  return lerp(d, e, t);
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to move along the Bezier path.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "bezierType",
+    label: "Curve type",
+    description: "Use quadratic (3 points) or cubic (4 points)",
+    type: "select",
+    options: [
+      ["quadratic", "Quadratic"],
+      ["cubic", "Cubic"],
+    ],
+    defaultValue: "quadratic",
+  },
+  {
+    key: "incremental",
+    label: "Increment per update",
+    description:
+      "Lerp step in 0..255 units per update. Larger values finish faster.",
+    type: "number",
+    min: 1,
+    max: 255,
+    defaultValue: 8,
+  },
+  {
+    key: "stepFrames",
+    label: "Update every (frames)",
+    description:
+      "Frames to keep each generated segment velocity (uses idles/wait_frames).",
+    type: "number",
+    min: 1,
+    max: 32,
+    defaultValue: 1,
+  },
+  {
+    key: "cycles",
+    label: "Cycles (0 = forever)",
+    description: "Number of times to repeat the generated Bezier motion",
+    type: "number",
+    min: 0,
+    max: 255,
+    defaultValue: 1,
+  },
+  {
+    key: "stopAtEnd",
+    label: "Stop at end",
+    description: "Zero velocity when finished",
+    type: "checkbox",
+    defaultValue: true,
+  },
+  {
+    key: "p0x",
+    label: "P0 X (px)",
+    type: "number",
+    min: -128,
+    max: 127,
+    width: "50%",
+    defaultValue: 0,
+  },
+  {
+    key: "p0y",
+    label: "P0 Y (px)",
+    type: "number",
+    min: -128,
+    max: 127,
+    width: "50%",
+    defaultValue: 0,
+  },
+  {
+    key: "p1x",
+    label: "P1 X (px)",
+    type: "number",
+    min: -128,
+    max: 127,
+    width: "50%",
+    defaultValue: 32,
+  },
+  {
+    key: "p1y",
+    label: "P1 Y (px)",
+    type: "number",
+    min: -128,
+    max: 127,
+    width: "50%",
+    defaultValue: 0,
+  },
+  {
+    key: "p2x",
+    label: "P2 X (px)",
+    type: "number",
+    min: -128,
+    max: 127,
+    width: "50%",
+    defaultValue: 64,
+  },
+  {
+    key: "p2y",
+    label: "P2 Y (px)",
+    type: "number",
+    min: -128,
+    max: 127,
+    width: "50%",
+    defaultValue: 32,
+  },
+  {
+    key: "p3x",
+    label: "P3 X (px)",
+    type: "number",
+    min: -128,
+    max: 127,
+    width: "50%",
+    defaultValue: 96,
+    conditions: [
+      {
+        key: "bezierType",
+        eq: "cubic",
+      },
+    ],
+  },
+  {
+    key: "p3y",
+    label: "P3 Y (px)",
+    type: "number",
+    min: -128,
+    max: 127,
+    width: "50%",
+    defaultValue: 0,
+    conditions: [
+      {
+        key: "bezierType",
+        eq: "cubic",
+      },
+    ],
+  },
+];
+
+export const compile = (input, helpers) => {
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPushConst,
+    _stackPop,
+    _addComment,
+    _addNL,
+    _declareLocal,
+    _setConst,
+    _invoke,
+    _idle,
+    _label,
+    _jump,
+    _loop,
+    getNextLabel,
+  } = helpers;
+
+  const clampInt = (v, min, max, dflt) => {
+    const n = Math.round(Number(v));
+    if (!isFinite(n)) return dflt;
+    return Math.max(min, Math.min(max, n));
+  };
+
+  const incremental = clampInt(input.incremental, 1, 255, 8);
+  const stepFrames = clampInt(input.stepFrames, 1, 32, 1);
+  const cycles = clampInt(input.cycles, 0, 255, 1);
+
+  const p0x = clampInt(input.p0x, -128, 127, 0);
+  const p0y = clampInt(input.p0y, -128, 127, 0);
+  const p1x = clampInt(input.p1x, -128, 127, 32);
+  const p1y = clampInt(input.p1y, -128, 127, 0);
+  const p2x = clampInt(input.p2x, -128, 127, 64);
+  const p2y = clampInt(input.p2y, -128, 127, 32);
+  const p3x = clampInt(input.p3x, -128, 127, 96);
+  const p3y = clampInt(input.p3y, -128, 127, 0);
+
+  const actorRef = _declareLocal("actorRef", 1, true);
+  const waitArgsRef = _declareLocal("wait_args", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+
+  const isCubic = input.bezierType === "cubic";
+
+  _addComment(`Actor Motion: Bezier Pattern (${isCubic ? "cubic" : "quadratic"})`);
+
+  const waitN = (frames) => {
+    if (frames <= 0) return;
+    if (frames < 5) {
+      for (let i = 0; i < frames; i++) _idle();
+    } else {
+      _setConst(waitArgsRef, frames);
+      _invoke("wait_frames", 0, waitArgsRef);
+    }
+  };
+
+  const setVelXY = (vx, vy) => {
+    _stackPushConst(vy);
+    _stackPushConst(vx);
+    _stackPush(actorRef);
+    _callNative("vm_set_actor_velocity");
+    _stackPop(3);
+  };
+
+  const checkpoints = [];
+  checkpoints.push({
+    x: 0,
+    y: 0,
+  });
+
+  for (let t = incremental; ; t += incremental) {
+    const clamped = Math.min(255, t);
+    const s = clamped / 255;
+    const x = isCubic
+      ? cubicBezier(p0x, p1x, p2x, p3x, s) - p0x
+      : quadraticBezier(p0x, p1x, p2x, s) - p0x;
+    const y = isCubic
+      ? cubicBezier(p0y, p1y, p2y, p3y, s) - p0y
+      : quadraticBezier(p0y, p1y, p2y, s) - p0y;
+    checkpoints.push({
+      x: Math.round(x * 32),
+      y: Math.round(y * 32),
+    });
+    if (clamped === 255) break;
+  }
+
+  const segments = [];
+  for (let i = 1; i < checkpoints.length; i++) {
+    const dx = checkpoints[i].x - checkpoints[i - 1].x;
+    const dy = checkpoints[i].y - checkpoints[i - 1].y;
+    segments.push({
+      vx: Math.round(dx / stepFrames),
+      vy: Math.round(dy / stepFrames),
+    });
+  }
+
+  const emitPath = () => {
+    for (let i = 0; i < segments.length; i++) {
+      setVelXY(segments[i].vx, segments[i].vy);
+      waitN(stepFrames);
+    }
+  };
+
+  if (cycles === 0) {
+    const topLabel = getNextLabel();
+    _label(topLabel);
+    emitPath();
+    _jump(topLabel);
+  } else if (cycles === 1) {
+    emitPath();
+  } else {
+    const counterRef = _declareLocal("cycle_count", 1, true);
+    const topLabel = getNextLabel();
+    _setConst(counterRef, cycles - 1);
+    _label(topLabel);
+    emitPath();
+    _loop(counterRef, topLabel, 0);
+  }
+
+  if (cycles !== 0 && input.stopAtEnd !== false) {
+    setVelXY(0, 0);
+  }
+
+  _addNL();
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionChargeByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionChargeByIndex.js
@@ -1,0 +1,204 @@
+const WAIT_COL_H = 0x01;
+const WAIT_COL_V = 0x02;
+const WAIT_COL_PIT = 0x04;
+const WAIT_COL_ACTOR = 0x08;
+
+export const id = "EVENT_ACTOR_MOTION_CHARGE_BY_INDEX";
+export const name = "Actor Motion: Charge At Target By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg, input) => {
+  return `Charge At Target : ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor that charges. Needs a behavior with movement on the dash axis. One event = one charge: wait until aligned with the target, dash at it, stop on impact - place it in a loop.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "targetActorIndex",
+    label: "Charge at index",
+    description: "Index of the actor to charge at (0 = player).",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "dashAxis",
+    label: "Dash axis",
+    description:
+      "Horizontal = dash sideways when the target is on the same row; Vertical = dash up/down when the target is on the same column",
+    type: "select",
+    options: [
+      ["x", "Horizontal"],
+      ["y", "Vertical"],
+    ],
+    defaultValue: "x",
+  },
+  {
+    key: "alignRange",
+    label: "Alignment range (px)",
+    description:
+      "How close the target must be on the other axis to trigger the charge",
+    type: "number",
+    min: 1,
+    max: 160,
+    defaultValue: 8,
+  },
+  {
+    key: "dashVelocity",
+    label: "Dash speed",
+    description:
+      "Dash velocity in subpixels per frame (32 = 1 pixel/frame, max 127)",
+    type: "number",
+    min: 1,
+    max: 127,
+    defaultValue: 64,
+  },
+  {
+    key: "stopOnLedge",
+    label: "Stop at ledges",
+    description:
+      "Also stop the dash at a ledge/pit edge (horizontal dash only, needs the Ledge stop component)",
+    type: "checkbox",
+    defaultValue: false,
+  },
+  {
+    key: "stopOnActor",
+    label: "Stop on actor collision",
+    description:
+      "Also stop the dash when hitting another collidable actor (needs the Actor collision component)",
+    type: "checkbox",
+    defaultValue: false,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_VM_WAIT_FOR_COLLISION", "VM: Wait for collision");
+
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPushConst,
+    _stackPop,
+    _addComment,
+    _addNL,
+    _declareLocal,
+    _invoke,
+    _idle,
+    _label,
+    _jump,
+    _if,
+    _ifConst,
+    _rpn,
+    _actorGetPosition,
+    _localRef,
+    getNextLabel,
+  } = helpers;
+
+  const clampInt = (v, min, max, dflt) => {
+    const n = Math.round(Number(v));
+    if (!isFinite(n)) return dflt;
+    return Math.max(min, Math.min(max, n));
+  };
+
+  const alignRange = clampInt(input.alignRange, 1, 160, 8);
+  const dashVel = clampInt(input.dashVelocity, 1, 127, 64);
+  const axis = input.dashAxis === "y" ? "y" : "x";
+  // Position offsets inside the fetched actor struct: 1 = x, 2 = y
+  const dashOff = axis === "x" ? 1 : 2;
+  const alignOff = axis === "x" ? 2 : 1;
+  const setNative =
+    axis === "x" ? "vm_set_actor_velocity_x" : "vm_set_actor_velocity_y";
+
+  let waitFlags = axis === "x" ? WAIT_COL_H : WAIT_COL_V;
+  if (axis === "x" && input.stopOnLedge === true) waitFlags |= WAIT_COL_PIT;
+  if (input.stopOnActor === true) waitFlags |= WAIT_COL_ACTOR;
+
+  const actorRef = _declareLocal("tmp0", 1, true);
+  const selfPos = _declareLocal("chg_pos_a", 4, true);
+  const targetPos = _declareLocal("chg_pos_b", 4, true);
+  const flagRef = _declareLocal("chg_flag", 1, true);
+
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  variableSetToScriptValue(selfPos, input.actorIndex);
+  variableSetToScriptValue(targetPos, input.targetActorIndex);
+
+  _addComment(`Actor Motion: Charge At Target (${axis})`);
+
+  const setDashVel = (v) => {
+    _stackPushConst(v);
+    _stackPush(actorRef);
+    _callNative(setNative);
+    _stackPop(2);
+  };
+
+  // Watch: idle until the target is aligned on the other axis
+  const detectLabel = getNextLabel();
+  const chargeLabel = getNextLabel();
+  _label(detectLabel);
+  _actorGetPosition(selfPos);
+  _actorGetPosition(targetPos);
+  _rpn()
+    .ref(_localRef(selfPos, alignOff))
+    .ref(_localRef(targetPos, alignOff))
+    .operator(".SUB")
+    .operator(".ABS")
+    .int16(alignRange * 32)
+    .operator(".LTE")
+    .refSet(flagRef)
+    .stop();
+  _ifConst(".EQ", flagRef, 1, chargeLabel, 0);
+  _idle();
+  _jump(detectLabel);
+
+  // Dash toward the target's side
+  _label(chargeLabel);
+  const negLabel = getNextLabel();
+  const joinLabel = getNextLabel();
+  _if(
+    ".LT",
+    _localRef(targetPos, dashOff),
+    _localRef(selfPos, dashOff),
+    negLabel,
+    0,
+  );
+  setDashVel(dashVel);
+  _jump(joinLabel);
+  _label(negLabel);
+  setDashVel(-dashVel);
+  _label(joinLabel);
+
+  // Charge until something stops us, then halt
+  _stackPushConst(waitFlags);
+  _stackPush(actorRef);
+  _invoke("vm_wait_for_collision", 2, ".ARG1");
+  setDashVel(0);
+
+  _addNL();
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionCircleByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionCircleByIndex.js
@@ -1,0 +1,228 @@
+export const id = "EVENT_ACTOR_MOTION_CIRCLE_BY_INDEX";
+export const name = "Actor Motion: Circle / Arc By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg, input) => {
+  return `Circle Motion : ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to move. Needs a behavior with Move X and Move Y enabled (usually with tile collision off).",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "radius",
+    label: "Radius (px)",
+    description: "Circle radius in pixels",
+    type: "number",
+    min: 1,
+    max: 127,
+    defaultValue: 24,
+  },
+  {
+    key: "period",
+    label: "Period (frames)",
+    description: "Frames for one full revolution (60 = 1 second)",
+    type: "number",
+    min: 16,
+    max: 1024,
+    defaultValue: 180,
+  },
+  {
+    key: "direction",
+    label: "Direction",
+    description: "Direction of rotation",
+    type: "select",
+    options: [
+      ["cw", "Clockwise"],
+      ["ccw", "Counter-clockwise"],
+    ],
+    defaultValue: "cw",
+  },
+  {
+    key: "startAngle",
+    label: "Start angle (degrees)",
+    description:
+      "Where on the circle the actor starts: 0 = top of the circle, 90 = right, 180 = bottom, 270 = left",
+    type: "number",
+    min: 0,
+    max: 359,
+    defaultValue: 0,
+  },
+  {
+    key: "arcDegrees",
+    label: "Arc (degrees)",
+    description:
+      "How much of the circle to travel. 360 = full circle (loops without drift), 180 = half circle (u-turn / swoop arc).",
+    type: "number",
+    min: 15,
+    max: 360,
+    defaultValue: 360,
+  },
+  {
+    key: "stepFrames",
+    label: "Update every (frames)",
+    description:
+      "Frames between velocity updates. Smaller = smoother but more script commands.",
+    type: "number",
+    min: 1,
+    max: 32,
+    defaultValue: 4,
+  },
+  {
+    key: "cycles",
+    label: "Cycles (0 = forever)",
+    description: "Number of times to run the circle/arc before continuing",
+    type: "number",
+    min: 0,
+    max: 255,
+    defaultValue: 1,
+  },
+  {
+    key: "stopAtEnd",
+    label: "Stop at end",
+    description:
+      "Zero the velocity when done. Turn off to chain seamlessly into another motion.",
+    type: "checkbox",
+    defaultValue: true,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPushConst,
+    _stackPop,
+    _addComment,
+    _addNL,
+    _declareLocal,
+    _setConst,
+    _invoke,
+    _idle,
+    _label,
+    _jump,
+    _loop,
+    getNextLabel,
+  } = helpers;
+
+  const clampInt = (v, min, max, dflt) => {
+    const n = Math.round(Number(v));
+    if (!isFinite(n)) return dflt;
+    return Math.max(min, Math.min(max, n));
+  };
+
+  const radius = clampInt(input.radius, 1, 127, 24);
+  const period = clampInt(input.period, 16, 1024, 180);
+  let stepFrames = clampInt(input.stepFrames, 1, 32, 4);
+  const cycles = clampInt(input.cycles, 0, 255, 1);
+  const startAngle = clampInt(input.startAngle, 0, 359, 0);
+  const arcDegrees = clampInt(input.arcDegrees, 15, 360, 360);
+  const dir = input.direction === "ccw" ? -1 : 1;
+
+  // Frames spent on the requested arc
+  const arcFrames = Math.max(stepFrames * 2, Math.round((period * arcDegrees) / 360));
+  let steps = Math.round(arcFrames / stepFrames);
+  if (steps > 64) {
+    stepFrames = Math.ceil(arcFrames / 64);
+    steps = Math.round(arcFrames / stepFrames);
+  }
+  if (steps < 2) steps = 2;
+
+  // Quantized circle: boundary positions snapped to multiples of stepFrames so
+  // every segment velocity is an integer; a full 360 arc closes exactly (zero
+  // drift when looped). Angle 0 = top of circle; position x = R*sin, y = -R*cos.
+  const theta0 = (startAngle * Math.PI) / 180;
+  const arcRad = (arcDegrees * Math.PI) / 180;
+  let velsX, velsY;
+  const buildVels = (r) => {
+    velsX = [];
+    velsY = [];
+    let prevX = Math.round((r * Math.sin(theta0)) / stepFrames) * stepFrames;
+    let prevY = Math.round((-r * Math.cos(theta0)) / stepFrames) * stepFrames;
+    for (let k = 1; k <= steps; k++) {
+      const theta = theta0 + dir * ((arcRad * k) / steps);
+      const px = Math.round((r * Math.sin(theta)) / stepFrames) * stepFrames;
+      const py = Math.round((-r * Math.cos(theta)) / stepFrames) * stepFrames;
+      velsX.push((px - prevX) / stepFrames);
+      velsY.push((py - prevY) / stepFrames);
+      prevX = px;
+      prevY = py;
+    }
+  };
+  let r = radius * 32;
+  buildVels(r);
+  // Engine velocities are int8: if the orbit is too fast for +-127 subpx/frame,
+  // scale the radius down to the fastest orbit that fits
+  const maxV = Math.max(...velsX.map(Math.abs), ...velsY.map(Math.abs));
+  if (maxV > 127) {
+    r = Math.trunc((r * 127) / maxV);
+    buildVels(r);
+  }
+
+  const actorRef = _declareLocal("tmp0", 1, true);
+  const waitArgsRef = _declareLocal("wait_args", 1, true);
+
+  variableSetToScriptValue(actorRef, input.actorIndex);
+
+  _addComment(
+    `Actor Motion: Circle (r ${radius}px, ${arcDegrees} deg, ${
+      steps * stepFrames
+    }f)`,
+  );
+
+  const setVelXY = (vx, vy) => {
+    _stackPushConst(vy);
+    _stackPushConst(vx);
+    _stackPush(actorRef);
+    _callNative("vm_set_actor_velocity");
+    _stackPop(3);
+  };
+
+  const waitN = (frames) => {
+    if (frames <= 0) return;
+    if (frames < 5) {
+      for (let i = 0; i < frames; i++) _idle();
+    } else {
+      _setConst(waitArgsRef, frames);
+      _invoke("wait_frames", 0, waitArgsRef);
+    }
+  };
+
+  const emitCycle = () => {
+    for (let k = 0; k < steps; k++) {
+      setVelXY(velsX[k], velsY[k]);
+      waitN(stepFrames);
+    }
+  };
+
+  if (cycles === 0) {
+    const topLabel = getNextLabel();
+    _label(topLabel);
+    emitCycle();
+    _jump(topLabel);
+  } else if (cycles === 1) {
+    emitCycle();
+  } else {
+    const counterRef = _declareLocal("cycle_count", 1, true);
+    _setConst(counterRef, cycles - 1);
+    const topLabel = getNextLabel();
+    _label(topLabel);
+    emitCycle();
+    _loop(counterRef, topLabel, 0);
+  }
+
+  if (cycles !== 0 && input.stopAtEnd !== false) {
+    setVelXY(0, 0);
+  }
+
+  _addNL();
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionSineByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionSineByIndex.js
@@ -1,0 +1,207 @@
+export const id = "EVENT_ACTOR_MOTION_SINE_BY_INDEX";
+export const name = "Actor Motion: Sine Wave By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg, input) => {
+  return `Sine Wave Motion : ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to move. Needs a behavior with Move X / Move Y enabled.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "axis",
+    label: "Axis",
+    description: "Axis to oscillate on. The other axis is left untouched.",
+    type: "select",
+    options: [
+      ["y", "Vertical (Y)"],
+      ["x", "Horizontal (X)"],
+    ],
+    defaultValue: "y",
+  },
+  {
+    key: "amplitude",
+    label: "Amplitude (px)",
+    description: "Peak distance from the start position, in pixels",
+    type: "number",
+    min: 1,
+    max: 127,
+    defaultValue: 16,
+  },
+  {
+    key: "period",
+    label: "Period (frames)",
+    description: "Frames for one full wave cycle (60 = 1 second)",
+    type: "number",
+    min: 8,
+    max: 1024,
+    defaultValue: 120,
+  },
+  {
+    key: "stepFrames",
+    label: "Update every (frames)",
+    description:
+      "Frames between velocity updates. Smaller = smoother but more script commands.",
+    type: "number",
+    min: 1,
+    max: 32,
+    defaultValue: 4,
+  },
+  {
+    key: "invert",
+    label: "Invert (start moving up / left)",
+    description: "Start the wave in the negative direction",
+    type: "checkbox",
+    defaultValue: false,
+  },
+  {
+    key: "cycles",
+    label: "Cycles (0 = forever)",
+    description: "Number of full wave cycles to run before continuing",
+    type: "number",
+    min: 0,
+    max: 255,
+    defaultValue: 1,
+  },
+  {
+    key: "stopAtEnd",
+    label: "Stop at end",
+    description:
+      "Zero the axis velocity when done. Turn off to chain seamlessly into another motion.",
+    type: "checkbox",
+    defaultValue: true,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPushConst,
+    _stackPop,
+    _addComment,
+    _addNL,
+    _declareLocal,
+    _setConst,
+    _invoke,
+    _idle,
+    _label,
+    _jump,
+    _loop,
+    getNextLabel,
+  } = helpers;
+
+  const clampInt = (v, min, max, dflt) => {
+    const n = Math.round(Number(v));
+    if (!isFinite(n)) return dflt;
+    return Math.max(min, Math.min(max, n));
+  };
+
+  const amplitude = clampInt(input.amplitude, 1, 127, 16);
+  const period = clampInt(input.period, 8, 1024, 120);
+  let stepFrames = clampInt(input.stepFrames, 1, 32, 4);
+  const cycles = clampInt(input.cycles, 0, 255, 1);
+  const axis = input.axis === "x" ? "x" : "y";
+  const invert = input.invert === true;
+
+  // Number of velocity segments per cycle (capped to keep script size sane)
+  let steps = Math.round(period / stepFrames);
+  if (steps > 64) {
+    stepFrames = Math.ceil(period / 64);
+    steps = Math.round(period / stepFrames);
+  }
+  if (steps < 2) steps = 2;
+
+  // Quantized wave: boundary positions are snapped to multiples of stepFrames
+  // so every segment velocity is an integer and the cycle closes exactly
+  // (zero drift, safe to loop forever). Positions in subpixels (32 = 1px).
+  const buildVels = (a) => {
+    const out = [];
+    let prev = 0;
+    for (let k = 1; k <= steps; k++) {
+      const ideal = a * Math.sin((2 * Math.PI * k) / steps);
+      const snapped = Math.round(ideal / stepFrames) * stepFrames;
+      out.push((snapped - prev) / stepFrames);
+      prev = snapped;
+    }
+    return out;
+  };
+  let amp = amplitude * 32 * (invert ? -1 : 1);
+  let vels = buildVels(amp);
+  // Engine velocities are int8: if the wave is too fast for +-127 subpx/frame,
+  // scale the amplitude down to the fastest wave that fits
+  const maxV = Math.max(...vels.map(Math.abs));
+  if (maxV > 127) {
+    amp = Math.trunc((amp * 127) / maxV);
+    vels = buildVels(amp);
+  }
+
+  const actorRef = _declareLocal("tmp0", 1, true);
+  const waitArgsRef = _declareLocal("wait_args", 1, true);
+
+  variableSetToScriptValue(actorRef, input.actorIndex);
+
+  _addComment(
+    `Actor Motion: Sine Wave (${axis}, amp ${amplitude}px, period ${
+      steps * stepFrames
+    }f)`,
+  );
+
+  const setAxisVel = (v) => {
+    _stackPushConst(v);
+    _stackPush(actorRef);
+    _callNative(
+      axis === "x" ? "vm_set_actor_velocity_x" : "vm_set_actor_velocity_y",
+    );
+    _stackPop(2);
+  };
+
+  const waitN = (frames) => {
+    if (frames <= 0) return;
+    if (frames < 5) {
+      for (let i = 0; i < frames; i++) _idle();
+    } else {
+      _setConst(waitArgsRef, frames);
+      _invoke("wait_frames", 0, waitArgsRef);
+    }
+  };
+
+  const emitCycle = () => {
+    for (const v of vels) {
+      setAxisVel(v);
+      waitN(stepFrames);
+    }
+  };
+
+  if (cycles === 0) {
+    const topLabel = getNextLabel();
+    _label(topLabel);
+    emitCycle();
+    _jump(topLabel);
+  } else if (cycles === 1) {
+    emitCycle();
+  } else {
+    const counterRef = _declareLocal("cycle_count", 1, true);
+    _setConst(counterRef, cycles - 1);
+    const topLabel = getNextLabel();
+    _label(topLabel);
+    emitCycle();
+    _loop(counterRef, topLabel, 0);
+  }
+
+  if (cycles !== 0 && input.stopAtEnd !== false) {
+    setAxisVel(0);
+  }
+
+  _addNL();
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionSwoopByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionSwoopByIndex.js
@@ -1,0 +1,175 @@
+export const id = "EVENT_ACTOR_MOTION_SWOOP_BY_INDEX";
+export const name = "Actor Motion: Swoop By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg, input) => {
+  return `Swoop Motion : ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to move. Needs a behavior with Move Y enabled (no gravity). X velocity is left untouched, so set it separately to swoop while flying (e.g. bat / keese dive).",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "depth",
+    label: "Dive depth (px)",
+    description: "How far down the swoop reaches, in pixels",
+    type: "number",
+    min: 1,
+    max: 127,
+    defaultValue: 32,
+  },
+  {
+    key: "diveFrames",
+    label: "Dive time (frames)",
+    description: "Frames spent diving down (eased, fast in the middle)",
+    type: "number",
+    min: 8,
+    max: 512,
+    defaultValue: 30,
+  },
+  {
+    key: "climbFrames",
+    label: "Climb time (frames)",
+    description:
+      "Frames spent climbing back up. Longer than the dive gives a natural fast-dive / slow-recover swoop.",
+    type: "number",
+    min: 8,
+    max: 512,
+    defaultValue: 60,
+  },
+  {
+    key: "invert",
+    label: "Invert (rise then dive)",
+    description: "Swoop upward first instead of downward",
+    type: "checkbox",
+    defaultValue: false,
+  },
+  {
+    key: "stepFrames",
+    label: "Update every (frames)",
+    description:
+      "Frames between velocity updates. Smaller = smoother but more script commands.",
+    type: "number",
+    min: 1,
+    max: 32,
+    defaultValue: 3,
+  },
+  {
+    key: "stopAtEnd",
+    label: "Stop at end",
+    description:
+      "Zero the Y velocity when done. Turn off to chain seamlessly into another motion.",
+    type: "checkbox",
+    defaultValue: true,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPushConst,
+    _stackPop,
+    _addComment,
+    _addNL,
+    _declareLocal,
+    _setConst,
+    _invoke,
+    _idle,
+  } = helpers;
+
+  const clampInt = (v, min, max, dflt) => {
+    const n = Math.round(Number(v));
+    if (!isFinite(n)) return dflt;
+    return Math.max(min, Math.min(max, n));
+  };
+
+  const depth = clampInt(input.depth, 1, 127, 32);
+  const diveFrames = clampInt(input.diveFrames, 8, 512, 30);
+  const climbFrames = clampInt(input.climbFrames, 8, 512, 60);
+  let stepFrames = clampInt(input.stepFrames, 1, 32, 3);
+  const sign = input.invert === true ? -1 : 1;
+
+  // Cap total segments to keep script size sane
+  if (Math.round((diveFrames + climbFrames) / stepFrames) > 64) {
+    stepFrames = Math.ceil((diveFrames + climbFrames) / 64);
+  }
+
+  // Eased dive-then-climb: y(t) follows a half-cosine down over the dive and a
+  // half-cosine back up over the climb (velocity 0 at both ends, peak speed at
+  // the middle of each phase). Boundary positions are snapped to multiples of
+  // stepFrames so segment velocities are integers and the swoop returns to the
+  // exact start height (zero drift). Positions in subpixels (32 = 1px).
+  let vels;
+  const buildVels = (d) => {
+    vels = [];
+    let prev = 0;
+    const emitPhase = (frames, posFn) => {
+      let steps = Math.round(frames / stepFrames);
+      if (steps < 2) steps = 2;
+      for (let k = 1; k <= steps; k++) {
+        const ideal = posFn(k / steps);
+        const snapped = Math.round(ideal / stepFrames) * stepFrames;
+        vels.push((snapped - prev) / stepFrames);
+        prev = snapped;
+      }
+    };
+    emitPhase(diveFrames, (t) => (d * (1 - Math.cos(Math.PI * t))) / 2);
+    emitPhase(climbFrames, (t) => (d * (1 + Math.cos(Math.PI * t))) / 2);
+  };
+  let d = depth * 32 * sign;
+  buildVels(d);
+  // Engine velocities are int8: if the swoop is too fast for +-127 subpx/frame,
+  // scale the depth down to the fastest swoop that fits
+  const maxV = Math.max(...vels.map(Math.abs));
+  if (maxV > 127) {
+    d = Math.trunc((d * 127) / maxV);
+    buildVels(d);
+  }
+
+  const actorRef = _declareLocal("tmp0", 1, true);
+  const waitArgsRef = _declareLocal("wait_args", 1, true);
+
+  variableSetToScriptValue(actorRef, input.actorIndex);
+
+  _addComment(
+    `Actor Motion: Swoop (depth ${depth}px, ${diveFrames}+${climbFrames}f)`,
+  );
+
+  const setVelY = (v) => {
+    _stackPushConst(v);
+    _stackPush(actorRef);
+    _callNative("vm_set_actor_velocity_y");
+    _stackPop(2);
+  };
+
+  const waitN = (frames) => {
+    if (frames <= 0) return;
+    if (frames < 5) {
+      for (let i = 0; i < frames; i++) _idle();
+    } else {
+      _setConst(waitArgsRef, frames);
+      _invoke("wait_frames", 0, waitArgsRef);
+    }
+  };
+
+  for (const v of vels) {
+    setVelY(v);
+    waitN(stepFrames);
+  }
+
+  if (input.stopAtEnd !== false) {
+    setVelY(0);
+  }
+
+  _addNL();
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionWallCrawlByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorMotionWallCrawlByIndex.js
@@ -1,0 +1,96 @@
+export const id = "EVENT_ACTOR_MOTION_WALL_CRAWL_BY_INDEX";
+export const name = "Actor Motion: Wall Crawl By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg, input) => {
+  return `Wall Crawl : ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor that crawls along walls/ceilings/floors, wrapping around corners (Zelda Spark style). Needs a behavior with Move X + Move Y and tile collision OFF - the crawl logic is what follows the walls. Runs forever; a wall is a fully solid tile (map borders count as wall).",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "wallSide",
+    label: "Wall side",
+    description:
+      "Which hand stays on the wall. Right hand = travels clockwise around solid blocks; left hand = counter-clockwise.",
+    type: "select",
+    options: [
+      ["right", "Right hand (clockwise)"],
+      ["left", "Left hand (counter-clockwise)"],
+    ],
+    defaultValue: "right",
+  },
+  {
+    key: "startDirection",
+    label: "Start direction",
+    description:
+      "Initial crawl direction. If it's blocked or has no wall beside it, the crawler turns on the first step automatically.",
+    type: "select",
+    options: [
+      ["right", "Right"],
+      ["left", "Left"],
+      ["up", "Up"],
+      ["down", "Down"],
+    ],
+    defaultValue: "right",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_VM_MOTION_CRAWL_STEP", "VM motion: Crawl step");
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_MOVE_X", "Component: Move horizontally");
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_MOVE_Y", "Component: Move vertically");
+
+  const {
+    variableSetToScriptValue,
+    _invoke,
+    _stackPush,
+    _stackPushConst,
+    _addComment,
+    _declareLocal,
+  } = helpers;
+
+  const side = input.wallSide === "left" ? 1 : 0;
+  const dirValues = { up: 0, right: 1, down: 2, left: 3 };
+  const startDir =
+    dirValues[input.startDirection] !== undefined
+      ? dirValues[input.startDirection]
+      : 1;
+
+  const actorRef = _declareLocal("tmp0", 1, true);
+
+  variableSetToScriptValue(actorRef, input.actorIndex);
+
+  _addComment(`Actor Motion: Wall Crawl (${side ? "left" : "right"} hand)`);
+
+  _stackPush(actorRef);
+  _stackPushConst(startDir);
+  _stackPushConst(side);
+  _stackPushConst(0);
+  _stackPushConst(0);
+  _invoke("vm_actor_crawl_step", 5, ".ARG4");
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorMoveToPositionByVelocityByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorMoveToPositionByVelocityByIndex.js
@@ -1,0 +1,267 @@
+const l10n = require("../helpers/l10n").default;
+
+export const id = "EVENT_ACTOR_MOVE_TO_POSITION_BY_VELOCITY_BY_INDEX";
+export const name = "Actor Move To Position By Velocity By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+const ACTOR_ATTR_H_FIRST = 0x01;
+const ACTOR_ATTR_DIAGONAL = 0x04;
+const ACTOR_ATTR_RELATIVE_SNAP_PX = 0x08;
+const ACTOR_ATTR_RELATIVE_SNAP_TILE = 0x10;
+
+export const autoLabel = (fetchArg, input) => {
+  const unitPostfix =
+    input.units === "pixels" ? l10n("FIELD_PIXELS_SHORT") : "";
+  return l10n("EVENT_ACTOR_MOVE_TO_LABEL", {
+    actor: fetchArg("actorIndex"),
+    x: `${fetchArg("targetX")}${unitPostfix}`,
+    y: `${fetchArg("targetY")}${unitPostfix}`,
+  });
+};
+
+export const fields = [
+  {
+    key: "__section",
+    type: "tabs",
+    defaultValue: "movement",
+    variant: "eventSection",
+    values: {
+      movement: l10n("FIELD_MOVEMENT"),
+      options: l10n("FIELD_OPTIONS"),
+      presets: l10n("FIELD_PRESETS"),
+    },
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    flexBasis: "100%",
+    fields: [
+      {
+        key: "actorIndex",
+        label: "Actor Index",
+        description: "Index of the actor to move.",
+        type: "value",
+        defaultValue: {
+          type: "number",
+          value: 0,
+        },
+        flexBasis: 0,
+        minWidth: 150,
+      },
+      {
+        type: "group",
+        wrapItems: true,
+        fields: [
+          {
+            key: "targetX",
+            label: "Target X",
+            description: "Destination X position",
+            type: "value",
+            width: "50%",
+            defaultValue: {
+              type: "number",
+              value: 0,
+            },
+            unitsField: "units",
+            unitsDefault: "tiles",
+            unitsAllowed: ["tiles", "pixels"],
+          },
+          {
+            key: "targetY",
+            label: "Target Y",
+            description: "Destination Y position",
+            type: "value",
+            width: "50%",
+            defaultValue: {
+              type: "number",
+              value: 0,
+            },
+            unitsField: "units",
+            unitsDefault: "tiles",
+            unitsAllowed: ["tiles", "pixels"],
+          },
+        ],
+      },
+    ],
+    conditions: [
+      {
+        key: "__section",
+        in: ["movement", undefined],
+      },
+    ],
+  },
+  {
+    type: "group",
+    wrapItems: true,
+    flexBasis: "100%",
+    fields: [
+      {
+        key: "cancelOnCollision",
+        width: "50%",
+        flexBasis: 0,
+        minWidth: 150,
+        label: "Cancel on collision",
+        description:
+          "If enabled, cancel movement when the actor remains in the same position on the next pass despite having non-zero velocity.",
+        type: "checkbox",
+        defaultValue: true,
+      },
+      {
+        type: "group",
+        flexBasis: 0,
+        minWidth: 150,
+        alignBottom: true,
+        fields: [
+          {
+            key: "relative",
+            label: "Relative",
+            description:
+              "If enabled, target is applied as an offset from current position and snapped using units.",
+            type: "checkbox",
+            defaultValue: false,
+          },
+          {
+            key: "directToPoint",
+            label: "Direct to point",
+            description:
+              "Move using angle-based steering directly toward the destination for smoother non-45-degree diagonals.",
+            type: "checkbox",
+            defaultValue: false,
+          },
+          {
+            key: "moveType",
+            label: "Move type",
+            description:
+              "Choose axis order or diagonal movement, same semantics as vm_actor_move_to.",
+            hideLabel: true,
+            type: "moveType",
+            defaultValue: "horizontal",
+            flexBasis: 35,
+            flexGrow: 0,
+            alignBottom: true,
+          },
+        ],
+      },
+    ],
+    conditions: [
+      {
+        key: "__section",
+        in: ["options"],
+      },
+    ],
+  },
+  {
+    type: "presets",
+    conditions: [
+      {
+        key: "__section",
+        in: ["presets"],
+      },
+    ],
+  },
+];
+
+export const userPresetsGroups = [
+  {
+    id: "movement",
+    label: l10n("FIELD_MOVEMENT"),
+    fields: ["targetX", "targetY"],
+  },
+  {
+    id: "units",
+    label: l10n("FIELD_UNITS"),
+    fields: ["units"],
+  },
+  {
+    id: "options",
+    label: l10n("FIELD_OPTIONS"),
+    fields: ["cancelOnCollision", "relative", "directToPoint", "moveType"],
+    selected: true,
+  },
+];
+
+export const userPresetsIgnore = ["__section", "actorIndex"];
+
+const shiftLeftScriptValueConst = (value, num) => {
+  return {
+    type: "shl",
+    valueA: value,
+    valueB: {
+      type: "number",
+      value: num,
+    },
+  };
+};
+
+const scriptValueToPixels = (value, units) => {
+  if (units === "pixels") {
+    return value;
+  }
+  return shiftLeftScriptValueConst(value, 3);
+};
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_VM_MOTION_MOVE_TO_POS_BY_VELOCITY", "VM motion: Move to position by velocity");
+
+  const {
+    variableSetToScriptValue,
+    _invoke,
+    _stackPush,
+    _stackPushConst,
+    _stackPushScriptValue,
+    _addComment,
+    _declareLocal,
+  } = helpers;
+
+  const actorRef = _declareLocal("actorRef", 1, true);
+  let attr = 0;
+  variableSetToScriptValue(actorRef, input.actorIndex);
+
+  if (input.moveType === "diagonal") {
+    attr |= ACTOR_ATTR_DIAGONAL;
+  } else if (input.moveType === "horizontal") {
+    attr |= ACTOR_ATTR_H_FIRST;
+  }
+
+  if (input.relative) {
+    if (input.units === "pixels") {
+      attr |= ACTOR_ATTR_RELATIVE_SNAP_PX;
+    } else {
+      attr |= ACTOR_ATTR_RELATIVE_SNAP_TILE;
+    }
+  }
+
+  _addComment("Actor Move To Position By Velocity By Index");
+  _stackPush(actorRef);
+  _stackPushScriptValue(
+    scriptValueToPixels(input.targetX || { type: "number", value: 0 }, input.units),
+  );
+  _stackPushScriptValue(
+    scriptValueToPixels(input.targetY || { type: "number", value: 0 }, input.units),
+  );
+  _stackPushConst(attr);
+  _stackPushConst(input.directToPoint ? 1 : 0);
+  _stackPushConst(input.cancelOnCollision ? 1 : 0);
+  _stackPushConst(0);
+  _stackPushConst(0);
+  _stackPushConst(0);
+  _stackPushConst(0);
+
+  _invoke("vm_actor_move_to_pos_by_velocity", 10, ".ARG9");
+};
+

--- a/plugins/Mico27/DynamicActorPlugin/events/eventActorSetVelocityByAngleByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventActorSetVelocityByAngleByIndex.js
@@ -1,0 +1,79 @@
+export const id = "EVENT_ACTOR_SET_VELOCITY_BY_ANGLE_BY_INDEX";
+export const name = "Set Actor Velocity By Angle By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg, input) => {
+  return `Set Velocity By Angle : ${fetchArg("angle")} deg`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the velocity on.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "angle",
+    label: "Angle (degrees)",
+    description: "Direction of travel: 0 = up, 90 = right, 180 = down, 270 = left",
+    type: "number",
+    min: 0,
+    max: 359,
+    defaultValue: 90,
+  },
+  {
+    key: "speed",
+    label: "Speed",
+    description:
+      "Velocity in subpixels per frame (32 = 1 pixel/frame, max 127)",
+    type: "number",
+    min: 1,
+    max: 127,
+    defaultValue: 32,
+  },
+];
+
+export const compile = (input, helpers) => {
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPushConst,
+    _stackPop,
+    _addComment,
+    _addNL,
+    _declareLocal,
+  } = helpers;
+
+  const clampInt = (v, min, max, dflt) => {
+    const n = Math.round(Number(v));
+    if (!isFinite(n)) return dflt;
+    return Math.max(min, Math.min(max, n));
+  };
+
+  const angle = clampInt(input.angle, 0, 359, 90);
+  const speed = clampInt(input.speed, 1, 127, 32);
+
+  // 0 degrees = up, clockwise (same convention as projectile launch angles)
+  const rad = (angle * Math.PI) / 180;
+  const vx = Math.round(Math.sin(rad) * speed);
+  const vy = -Math.round(Math.cos(rad) * speed);
+
+  const actorRef = _declareLocal("tmp0", 1, true);
+  variableSetToScriptValue(actorRef, input.actorIndex);
+
+  _addComment(`Set Actor Velocity By Angle (${angle} deg, ${speed})`);
+
+  _stackPushConst(vy);
+  _stackPushConst(vx);
+  _stackPush(actorRef);
+  _callNative("vm_set_actor_velocity");
+  _stackPop(3);
+
+  _addNL();
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventClearActorParentActorByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventClearActorParentActorByIndex.js
@@ -1,0 +1,54 @@
+export const id = "EVENT_CLEAR_ACTOR_PARENT_ACTOR_BY_INDEX";
+export const name = "Clear Actor Parent Actor By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = (fetchArg) => {
+  return `Clear Actor Parent Actor : ${fetchArg("actorIndex")}`;
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to remove the parent from.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_PARENT", "Component: Parent actors / moving platforms");
+
+  const { variableSetToScriptValue, _callNative, _stackPush, _stackPushConst, _stackPop, _addComment, _declareLocal } =
+    helpers;
+
+  const tmp0 = _declareLocal("tmp0", 1, true);
+  variableSetToScriptValue(tmp0, input.actorIndex);
+
+  _addComment("Clear Actor Parent Actor By Index");
+
+  _stackPushConst(255);
+  _stackPush(tmp0);
+
+  _callNative("vm_set_actor_parent");
+  _stackPop(2);
+};
+

--- a/plugins/Mico27/DynamicActorPlugin/events/eventDefineActorBehavior.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventDefineActorBehavior.js
@@ -33,7 +33,6 @@ const BHV_EVENT_HIT_ACTORS = 0x40;
 const BHV_EVENT_ACTIVATE_TRIGGERS = 0x80;
 
 const DYNAMIC_ACTOR_COLLISION_SINGLE_POINT = 0;
-const DYNAMIC_ACTOR_COLLISION_TRIANGLE = 1;
 const DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX = 2;
 
 const PRESETS = {
@@ -261,7 +260,6 @@ export const fields = [
     type: "select",
     options: [
       [String(DYNAMIC_ACTOR_COLLISION_SINGLE_POINT), "Origin point (fastest)"],
-      [String(DYNAMIC_ACTOR_COLLISION_TRIANGLE), "Triangle"],
       [String(DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX), "Bounding box"],
     ],
     defaultValue: String(DYNAMIC_ACTOR_COLLISION_SINGLE_POINT),

--- a/plugins/Mico27/DynamicActorPlugin/events/eventDefineActorBehavior.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventDefineActorBehavior.js
@@ -33,6 +33,7 @@ const BHV_EVENT_HIT_ACTORS = 0x40;
 const BHV_EVENT_ACTIVATE_TRIGGERS = 0x80;
 
 const DYNAMIC_ACTOR_COLLISION_SINGLE_POINT = 0;
+const DYNAMIC_ACTOR_COLLISION_TRIANGLE = 1;
 const DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX = 2;
 
 const PRESETS = {
@@ -260,6 +261,7 @@ export const fields = [
     type: "select",
     options: [
       [String(DYNAMIC_ACTOR_COLLISION_SINGLE_POINT), "Origin point (fastest)"],
+      [String(DYNAMIC_ACTOR_COLLISION_TRIANGLE), "Triangle"],
       [String(DYNAMIC_ACTOR_COLLISION_BOUNDING_BOX), "Bounding box"],
     ],
     defaultValue: String(DYNAMIC_ACTOR_COLLISION_SINGLE_POINT),

--- a/plugins/Mico27/DynamicActorPlugin/events/eventGetActorZPositionByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventGetActorZPositionByIndex.js
@@ -1,0 +1,84 @@
+const l10n = require("../helpers/l10n").default;
+
+export const id = "EVENT_GET_ACTOR_Z_POSITION_BY_INDEX";
+export const name = "Get actor z position By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = () => {
+  return "Get actor z position";
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to get the Z position of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "variable",
+    label: l10n("FIELD_VARIABLE"),
+    description: l10n("FIELD_VARIABLE_DESC"),
+    type: "variable",
+    defaultValue: "LAST_VARIABLE",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_MOVE_Z", "Topdown Z axis");
+
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPop,
+    _addComment,
+    _declareLocal,
+    getVariableAlias,
+    _stackPushConst,
+    _isIndirectVariable,
+    _setInd,
+  } = helpers;
+
+  const tmp0 = _declareLocal("tmp0", 1, true);
+
+  variableSetToScriptValue(tmp0, input.actorIndex);
+
+  const variableAlias = getVariableAlias(input.variable);
+  let dest = variableAlias;
+  if (_isIndirectVariable(input.variable)) {
+    const zpos_result = _declareLocal("zpos_result", 1, true);
+    dest = zpos_result;
+  }
+
+  _addComment("Get actor z position By Index");
+
+  _stackPushConst(dest);
+  _stackPush(tmp0);
+
+  _callNative("vm_get_actor_z_position");
+  _stackPop(2);
+
+  if (_isIndirectVariable(input.variable)) {
+    _setInd(variableAlias, dest);
+  }
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventGetActorZVelocityByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventGetActorZVelocityByIndex.js
@@ -1,0 +1,84 @@
+const l10n = require("../helpers/l10n").default;
+
+export const id = "EVENT_GET_ACTOR_Z_VELOCITY_BY_INDEX";
+export const name = "Get actor z velocity By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = () => {
+  return "Get actor z velocity";
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to get the Z velocity of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "variable",
+    label: l10n("FIELD_VARIABLE"),
+    description: l10n("FIELD_VARIABLE_DESC"),
+    type: "variable",
+    defaultValue: "LAST_VARIABLE",
+  },
+];
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_MOVE_Z", "Topdown Z axis");
+
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPop,
+    _addComment,
+    _declareLocal,
+    getVariableAlias,
+    _stackPushConst,
+    _isIndirectVariable,
+    _setInd,
+  } = helpers;
+
+  const tmp0 = _declareLocal("tmp0", 1, true);
+
+  variableSetToScriptValue(tmp0, input.actorIndex);
+
+  const variableAlias = getVariableAlias(input.variable);
+  let dest = variableAlias;
+  if (_isIndirectVariable(input.variable)) {
+    const zvel_result = _declareLocal("zvel_result", 1, true);
+    dest = zvel_result;
+  }
+
+  _addComment("Get actor z velocity By Index");
+
+  _stackPushConst(dest);
+  _stackPush(tmp0);
+
+  _callNative("vm_get_actor_velocity_z");
+  _stackPop(2);
+
+  if (_isIndirectVariable(input.variable)) {
+    _setInd(variableAlias, dest);
+  }
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventSetActorZPositionByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventSetActorZPositionByIndex.js
@@ -1,0 +1,75 @@
+const l10n = require("../helpers/l10n").default;
+
+export const id = "EVENT_SET_ACTOR_Z_POSITION_BY_INDEX";
+export const name = "Set actor z position By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = () => {
+  return "Set actor z position";
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the Z position of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "zPosition",
+    label: "Z position",
+    description: "Actor Z position in subpixels (16 = 1 pixel)",
+    type: "value",
+    min: 0,
+    max: 32767,
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_MOVE_Z", "Topdown Z axis");
+
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPop,
+    _addComment,
+    _declareLocal,
+    _stackPushScriptValue,
+  } = helpers;
+
+  const tmp0 = _declareLocal("tmp0", 1, true);
+
+  variableSetToScriptValue(tmp0, input.actorIndex);
+
+  _addComment("Set actor z position By Index");
+
+  _stackPushScriptValue(input.zPosition);
+  _stackPush(tmp0);
+
+  _callNative("vm_set_actor_z_position");
+  _stackPop(2);
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventSetActorZVelocityByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventSetActorZVelocityByIndex.js
@@ -1,0 +1,75 @@
+const l10n = require("../helpers/l10n").default;
+
+export const id = "EVENT_SET_ACTOR_Z_VELOCITY_BY_INDEX";
+export const name = "Set actor z velocity By Index";
+export const groups = ["EVENT_GROUP_ACTOR"];
+
+export const autoLabel = () => {
+  return "Set actor z velocity";
+};
+
+export const fields = [
+  {
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor to set the Z velocity of.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+  {
+    key: "zVelocity",
+    label: "Z velocity",
+    description: "Actor Z velocity in subpixels per frame (16 = 1 pixel/frame)",
+    type: "value",
+    min: -128,
+    max: 127,
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
+  },
+];
+
+export const compile = (input, helpers) => {
+  const __engineFieldOn = (key) => {
+    const fv =
+      helpers.engineFieldValues &&
+      helpers.engineFieldValues.find((s) => s.id === key);
+    if (fv && fv.value !== undefined && fv.value !== null) return !!fv.value;
+    const def = helpers.engineFields && helpers.engineFields[key];
+    return def ? !!def.defaultValue : true;
+  };
+  const __requireEngineField = (key, label) => {
+    if (!__engineFieldOn(key)) {
+      throw new Error(
+        `This event requires the "${label}" engine setting to be enabled (Settings → Engine fields → Dynamic actor).`
+      );
+    }
+  };
+  __requireEngineField("DYNAMIC_ACTOR_ENABLE_MOVE_Z", "Topdown Z axis");
+
+  const {
+    variableSetToScriptValue,
+    _callNative,
+    _stackPush,
+    _stackPop,
+    _addComment,
+    _declareLocal,
+    _stackPushScriptValue,
+  } = helpers;
+
+  const tmp0 = _declareLocal("tmp0", 1, true);
+
+  variableSetToScriptValue(tmp0, input.actorIndex);
+
+  _addComment("Set actor z velocity By Index");
+
+  _stackPushScriptValue(input.zVelocity);
+  _stackPush(tmp0);
+
+  _callNative("vm_set_actor_velocity_z");
+  _stackPop(2);
+};

--- a/plugins/Mico27/DynamicActorPlugin/events/eventWaitForActorInRangeByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventWaitForActorInRangeByIndex.js
@@ -1,5 +1,3 @@
-const l10n = require("../helpers/l10n").default;
-
 const WAIT_RNG_X = 0x01;
 const WAIT_RNG_Y = 0x02;
 const WAIT_RNG_OUTSIDE = 0x04;
@@ -7,28 +5,34 @@ const WAIT_RNG_OUTSIDE = 0x04;
 // Pixel -> actor position subpixel scale
 const SUBPX = 32;
 
-export const id = "EVENT_WAIT_FOR_ACTOR_IN_RANGE";
-export const name = "Wait For Actor In Range";
+export const id = "EVENT_WAIT_FOR_ACTOR_IN_RANGE_BY_INDEX";
+export const name = "Wait For Actor In Range By Index";
 export const groups = ["EVENT_GROUP_ACTOR"];
 
 export const autoLabel = (fetchArg, input) => {
-  return `Wait For Actor In Range : ${fetchArg("actorId")}`;
+  return `Wait For Actor In Range : ${fetchArg("actorIndex")}`;
 };
 
 export const fields = [
   {
-    key: "actorId",
-    label: l10n("ACTOR"),
-    description: "Actor at the center of the range check",
-    type: "actor",
-    defaultValue: "$self$",
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor at the center of the range check.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
   },
   {
-    key: "targetActorId",
-    label: "Wait for",
-    description: "Actor whose distance is checked (usually the player)",
-    type: "actor",
-    defaultValue: "player",
+    key: "targetActorIndex",
+    label: "Wait for index",
+    description: "Index of the actor whose distance is checked (0 = player).",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
   },
   {
     key: "until",
@@ -110,9 +114,9 @@ export const compile = (input, helpers) => {
   );
 
   const {
+    variableSetToScriptValue,
     _addComment,
     _declareLocal,
-    setActorId,
     _stackPush,
     _stackPushConst,
     _invoke,
@@ -139,11 +143,8 @@ export const compile = (input, helpers) => {
   const actorRef = _declareLocal("rng_actor", 1, true);
   const targetRef = _declareLocal("rng_target", 1, true);
 
-  setActorId(actorRef, input.actorId);
-  setActorId(
-    targetRef,
-    input.targetActorId != null ? input.targetActorId : "player",
-  );
+  variableSetToScriptValue(actorRef, input.actorIndex);
+  variableSetToScriptValue(targetRef, input.targetActorIndex);
 
   _addComment(
     `Wait For Actor In Range (${waitForInside ? "inside" : "outside"})`,

--- a/plugins/Mico27/DynamicActorPlugin/events/eventWaitForActorStateByIndex.js
+++ b/plugins/Mico27/DynamicActorPlugin/events/eventWaitForActorStateByIndex.js
@@ -1,21 +1,21 @@
-const l10n = require("../helpers/l10n").default;
-
-export const id = "EVENT_WAIT_FOR_ACTOR_STATE";
-export const name = "Wait For Actor State";
+export const id = "EVENT_WAIT_FOR_ACTOR_STATE_BY_INDEX";
+export const name = "Wait For Actor State By Index";
 export const groups = ["EVENT_GROUP_ACTOR"];
 
 export const autoLabel = (fetchArg, input) => {
-  return `Wait For Actor State : ${fetchArg("actorId")}`;
+  return `Wait For Actor State : ${fetchArg("actorIndex")}`;
 };
 
 export const fields = [
   {
-    key: "actorId",
-    label: l10n("ACTOR"),
-    description:
-      "Actor whose behavior state to wait for. Grounded/airborne are managed by behaviors with Gravity + Move Y enabled.",
-    type: "actor",
-    defaultValue: "$self$",
+    key: "actorIndex",
+    label: "Actor Index",
+    description: "Index of the actor whose behavior state to wait for. Grounded/airborne are managed by behaviors with Gravity + Move Y enabled.",
+    type: "value",
+    defaultValue: {
+      type: "number",
+      value: 0,
+    },
   },
   {
     key: "state",
@@ -61,11 +61,11 @@ export const compile = (input, helpers) => {
   );
 
   const {
+    variableSetToScriptValue,
     _stackPush,
     _stackPushConst,
     _addComment,
     _declareLocal,
-    setActorId,
     _invoke,
   } = helpers;
 
@@ -76,7 +76,7 @@ export const compile = (input, helpers) => {
 
   const actorRef = _declareLocal("actorRef", 1, true);
 
-  setActorId(actorRef, input.actorId);
+  variableSetToScriptValue(actorRef, input.actorIndex);
 
   _addComment(`Wait For Actor State ${invert ? "!=" : "=="} ${state}`);
   _stackPush(actorRef);

--- a/plugins/Mico27/DynamicActorPlugin/plugin.json
+++ b/plugins/Mico27/DynamicActorPlugin/plugin.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/Mico27/gbs-DynamicActorPlugin",
   "description": "Allows dynamic actor behaviors that requires smooth perpixel movements such as gravity, velocity, actor attached to other actors, etc",
   "license": "MIT",
-  "version": "4.3.2",
+  "version": "4.3.0",
   "gbsVersion": ">=4.3.0",
   "order": -7,
   "engineAltRules": [

--- a/plugins/Mico27/DynamicActorPlugin/plugin.json
+++ b/plugins/Mico27/DynamicActorPlugin/plugin.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/Mico27/gbs-DynamicActorPlugin",
   "description": "Allows dynamic actor behaviors that requires smooth perpixel movements such as gravity, velocity, actor attached to other actors, etc",
   "license": "MIT",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "gbsVersion": ">=4.3.0",
   "order": -7,
   "engineAltRules": [

--- a/plugins/Mico27/MetaTilePlugin/engineAlt/Cont/src/core/meta_tiles.c
+++ b/plugins/Mico27/MetaTilePlugin/engineAlt/Cont/src/core/meta_tiles.c
@@ -331,7 +331,7 @@ static void impl_replace_meta_tile(UBYTE x, UBYTE y, UBYTE tile_id, UBYTE commit
             bkg_address_offset = (bkg_address_offset & 0xFFE0) + ((bkg_address_offset + 1) & 31);
             set_vram_byte((UBYTE*)(0x9800 + bkg_address_offset), ReadBankedUBYTE(metatile_attr_ptr + tile_map_offset, metatile_attr_bank));
         #else
-            set_bkg_tile_xy(x, y, ReadBankedUBYTE(metatile_attr_ptr + tile_id, metatile_attr_bank));
+            set_bkg_tile_xy((x + bkg_offset_x) & 31, (y + bkg_offset_y) & 31, ReadBankedUBYTE(metatile_attr_ptr + tile_id, metatile_attr_bank));
         #endif
             VBK_REG = 0;
         }
@@ -350,7 +350,7 @@ static void impl_replace_meta_tile(UBYTE x, UBYTE y, UBYTE tile_id, UBYTE commit
         bkg_address_offset = (bkg_address_offset & 0xFFE0) + ((bkg_address_offset + 1) & 31);
         set_vram_byte((UBYTE*)(0x9800 + bkg_address_offset), ReadBankedUBYTE(metatile_ptr + tile_map_offset, metatile_bank));
     #else
-        set_bkg_tile_xy(x, y, ReadBankedUBYTE(metatile_ptr + tile_id, metatile_bank));
+        set_bkg_tile_xy((x + bkg_offset_x) & 31, (y + bkg_offset_y) & 31, ReadBankedUBYTE(metatile_ptr + tile_id, metatile_bank));
     #endif
     }
 }

--- a/plugins/Mico27/MetaTilePlugin/engineAlt/Cont_ScreenS/src/core/meta_tiles.c
+++ b/plugins/Mico27/MetaTilePlugin/engineAlt/Cont_ScreenS/src/core/meta_tiles.c
@@ -287,7 +287,7 @@ static void impl_replace_meta_tile(UBYTE x, UBYTE y, UBYTE tile_id, UBYTE commit
             bkg_address_offset = (bkg_address_offset & 0xFFE0) + ((bkg_address_offset + 1) & 31);
             set_vram_byte((UBYTE*)(0x9800 + bkg_address_offset), ReadBankedUBYTE(metatile_attr_ptr + tile_map_offset, metatile_attr_bank));
         #else
-            set_bkg_tile_xy(x, y, ReadBankedUBYTE(metatile_attr_ptr + tile_id, metatile_attr_bank));
+            set_bkg_tile_xy((x + bkg_offset_x) & 31, (y + bkg_offset_y) & 31, ReadBankedUBYTE(metatile_attr_ptr + tile_id, metatile_attr_bank));
         #endif
             VBK_REG = 0;
         }
@@ -306,7 +306,7 @@ static void impl_replace_meta_tile(UBYTE x, UBYTE y, UBYTE tile_id, UBYTE commit
         bkg_address_offset = (bkg_address_offset & 0xFFE0) + ((bkg_address_offset + 1) & 31);
         set_vram_byte((UBYTE*)(0x9800 + bkg_address_offset), ReadBankedUBYTE(metatile_ptr + tile_map_offset, metatile_bank));
     #else
-        set_bkg_tile_xy(x, y, ReadBankedUBYTE(metatile_ptr + tile_id, metatile_bank));
+        set_bkg_tile_xy((x + bkg_offset_x) & 31, (y + bkg_offset_y) & 31, ReadBankedUBYTE(metatile_ptr + tile_id, metatile_bank));
     #endif
     }
 }

--- a/plugins/Mico27/MetaTilePlugin/engineAlt/ScreenS/src/core/meta_tiles.c
+++ b/plugins/Mico27/MetaTilePlugin/engineAlt/ScreenS/src/core/meta_tiles.c
@@ -287,7 +287,7 @@ static void impl_replace_meta_tile(UBYTE x, UBYTE y, UBYTE tile_id, UBYTE commit
             bkg_address_offset = (bkg_address_offset & 0xFFE0) + ((bkg_address_offset + 1) & 31);
             set_vram_byte((UBYTE*)(0x9800 + bkg_address_offset), ReadBankedUBYTE(metatile_attr_ptr + tile_map_offset, metatile_attr_bank));
         #else
-            set_bkg_tile_xy(x, y, ReadBankedUBYTE(metatile_attr_ptr + tile_id, metatile_attr_bank));
+            set_bkg_tile_xy((x + bkg_offset_x) & 31, (y + bkg_offset_y) & 31, ReadBankedUBYTE(metatile_attr_ptr + tile_id, metatile_attr_bank));
         #endif
             VBK_REG = 0;
         }
@@ -306,7 +306,7 @@ static void impl_replace_meta_tile(UBYTE x, UBYTE y, UBYTE tile_id, UBYTE commit
         bkg_address_offset = (bkg_address_offset & 0xFFE0) + ((bkg_address_offset + 1) & 31);
         set_vram_byte((UBYTE*)(0x9800 + bkg_address_offset), ReadBankedUBYTE(metatile_ptr + tile_map_offset, metatile_bank));
     #else
-        set_bkg_tile_xy(x, y, ReadBankedUBYTE(metatile_ptr + tile_id, metatile_bank));
+        set_bkg_tile_xy((x + bkg_offset_x) & 31, (y + bkg_offset_y) & 31, ReadBankedUBYTE(metatile_ptr + tile_id, metatile_bank));
     #endif
     }
 }

--- a/plugins/Mico27/MetaTilePlugin/plugin.json
+++ b/plugins/Mico27/MetaTilePlugin/plugin.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/Mico27/gbs-MetatilePlugin",
   "description": "Integrates the concept of metatiles in gbstudio",
   "license": "MIT",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "gbsVersion": ">=4.3.0",
   "order": -12,
   "engineAltRules": [


### PR DESCRIPTION
- Fix metatile plugin compability in 8px mode + Fix dynamic actor plugin topdown platform behavior

- Adding ByIndex variant of the actor events, optimized wait for actor in range and wait for actor state events remove events,
Removed triangle collision option (was cramping ROM bank when paired with plugins inflating the tile_at inline function)